### PR TITLE
feat(training): 트레이닝+실무투입 패키지 결제 페이지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@stagewise/toolbar-next": "^0.6.2",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.52.0",
+        "@tosspayments/tosspayments-sdk": "^2.7.1",
         "@vercel/analytics": "^1.5.0",
         "bcryptjs": "^2.4.3",
         "class-variance-authority": "^0.7.1",
@@ -2597,6 +2598,12 @@
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
       }
+    },
+    "node_modules/@tosspayments/tosspayments-sdk": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tosspayments/tosspayments-sdk/-/tosspayments-sdk-2.7.1.tgz",
+      "integrity": "sha512-nHInxgFvFGm1VtaCS+IPLdtmE+B2a+MCYE9Meq0aR/0L0hAgoGllLS4ciQGb1RtLvp3mHcj3lL80XMi4BqQ7uw==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@stagewise/toolbar-next": "^0.6.2",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.52.0",
+    "@tosspayments/tosspayments-sdk": "^2.7.1",
     "@vercel/analytics": "^1.5.0",
     "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.1",

--- a/src/app/api/training/checkout/route.ts
+++ b/src/app/api/training/checkout/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { randomBytes, randomUUID } from 'node:crypto'
+import { createClient } from '@supabase/supabase-js'
+import {
+  TRAINING_PRODUCT_SLUG,
+  buildDueDates,
+  buildOrderNo,
+  type TrainingPlan,
+} from '@/lib/training-package'
+
+function getSupabase() {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+}
+
+type Body = {
+  planCode?: string
+  name?: string
+  email?: string
+  phone?: string
+  nationality?: string
+  preferredLang?: string
+  memo?: string
+  agreed?: boolean
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+// 결제 시작 전 주문과 회차별 청구 레코드를 만든다.
+// 금액은 요청값을 신뢰하지 않고 DB의 요금제에서만 가져온다.
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as Body
+
+    const name = (body.name ?? '').trim()
+    const email = (body.email ?? '').trim().toLowerCase()
+    const phone = (body.phone ?? '').trim()
+    const nationality = (body.nationality ?? '').trim()
+    const preferredLang = ['ko', 'en', 'ja'].includes(body.preferredLang ?? '') ? body.preferredLang! : 'ko'
+    const planCode = (body.planCode ?? '').trim()
+
+    if (!name || name.length > 80) {
+      return NextResponse.json({ success: false, error: '이름을 입력해 주세요.' }, { status: 400 })
+    }
+    if (!EMAIL_RE.test(email) || email.length > 160) {
+      return NextResponse.json({ success: false, error: '이메일 형식을 확인해 주세요.' }, { status: 400 })
+    }
+    if (!body.agreed) {
+      return NextResponse.json({ success: false, error: '결제 진행에 동의해 주세요.' }, { status: 400 })
+    }
+
+    const supabase = getSupabase()
+
+    const { data: product, error: productError } = await supabase
+      .from('training_products')
+      .select('id, title, currency, is_active')
+      .eq('slug', TRAINING_PRODUCT_SLUG)
+      .maybeSingle()
+
+    if (productError || !product || !product.is_active) {
+      return NextResponse.json({ success: false, error: '판매 중인 상품을 찾을 수 없습니다.' }, { status: 404 })
+    }
+
+    const { data: planRow, error: planError } = await supabase
+      .from('training_price_plans')
+      .select('*')
+      .eq('product_id', product.id)
+      .eq('code', planCode)
+      .eq('is_active', true)
+      .maybeSingle()
+
+    if (planError || !planRow) {
+      return NextResponse.json({ success: false, error: '결제 방식을 다시 선택해 주세요.' }, { status: 400 })
+    }
+    const plan = planRow as unknown as TrainingPlan
+
+    const now = new Date()
+    const orderNo = buildOrderNo(now, randomBytes(3).toString('hex'))
+    const dueDates = buildDueDates(now, plan.installment_months)
+
+    const { data: order, error: orderError } = await supabase
+      .from('training_orders')
+      .insert({
+        order_no: orderNo,
+        product_id: product.id,
+        plan_id: plan.id,
+        customer_name: name,
+        customer_email: email,
+        customer_phone: phone || null,
+        customer_nationality: nationality || null,
+        preferred_lang: preferredLang,
+        pg_provider: 'toss',
+        currency: plan.currency,
+        total_amount: plan.total_amount,
+        installment_months: plan.installment_months,
+        status: 'pending',
+        memo: (body.memo ?? '').trim() || null,
+        billing_customer_key: randomUUID(),
+        next_billing_at: plan.installment_months > 1 ? `${dueDates[1]}T00:00:00+09:00` : null,
+      })
+      .select('id, order_no, billing_customer_key')
+      .single()
+
+    if (orderError || !order) {
+      console.error('[training/checkout] order insert failed:', orderError)
+      return NextResponse.json({ success: false, error: '주문 생성에 실패했습니다.' }, { status: 500 })
+    }
+
+    // 회차별 청구 레코드. 1회차만 지금 결제하고 나머지는 예정 상태로 둔다.
+    const payments = dueDates.map((due, index) => ({
+      order_id: order.id,
+      sequence: index + 1,
+      due_date: due,
+      amount: plan.amount_per_charge,
+      currency: plan.currency,
+      status: 'pending',
+      pg_provider: index === 0 ? 'toss' : null,
+      pg_order_id: index === 0 ? `${order.order_no}-1` : null,
+    }))
+
+    const { error: paymentsError } = await supabase.from('training_order_payments').insert(payments)
+    if (paymentsError) {
+      console.error('[training/checkout] payments insert failed:', paymentsError)
+      await supabase.from('training_orders').delete().eq('id', order.id)
+      return NextResponse.json({ success: false, error: '결제 정보 생성에 실패했습니다.' }, { status: 500 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      orderNo: order.order_no,
+      pgOrderId: `${order.order_no}-1`,
+      amount: plan.amount_per_charge,
+      totalAmount: plan.total_amount,
+      installmentMonths: plan.installment_months,
+      orderName:
+        plan.installment_months > 1
+          ? `${product.title} (${plan.label} 1/${plan.installment_months}회차)`
+          : `${product.title} (${plan.label})`,
+      customerKey: order.billing_customer_key,
+    })
+  } catch (error) {
+    console.error('[training/checkout] unexpected error:', error)
+    return NextResponse.json({ success: false, error: '요청 처리 중 오류가 발생했습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/api/training/confirm/route.ts
+++ b/src/app/api/training/confirm/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+function getSupabase() {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+}
+
+type Body = {
+  paymentKey?: string
+  orderId?: string
+  amount?: number
+}
+
+// 토스 결제 승인 → 회차 결제 레코드 확정.
+// 금액은 DB의 청구 레코드와 대조해 위변조를 막고, paymentKey 기준으로 멱등 처리한다.
+export async function POST(request: NextRequest) {
+  try {
+    const { paymentKey, orderId, amount } = (await request.json()) as Body
+    if (!paymentKey || !orderId || typeof amount !== 'number') {
+      return NextResponse.json({ success: false, error: '결제 정보가 누락되었습니다.' }, { status: 400 })
+    }
+
+    const supabase = getSupabase()
+
+    const { data: paymentRow, error: paymentError } = await supabase
+      .from('training_order_payments')
+      .select('id, order_id, sequence, amount, status, payment_key')
+      .eq('pg_order_id', orderId)
+      .maybeSingle()
+
+    if (paymentError || !paymentRow) {
+      return NextResponse.json({ success: false, error: '주문을 찾을 수 없습니다.' }, { status: 404 })
+    }
+
+    // 멱등: 이미 승인된 회차면 그대로 성공 응답.
+    if (paymentRow.status === 'paid') {
+      const { data: paidOrder } = await supabase
+        .from('training_orders')
+        .select('order_no')
+        .eq('id', paymentRow.order_id)
+        .maybeSingle()
+      return NextResponse.json({ success: true, idempotent: true, orderNo: paidOrder?.order_no ?? null })
+    }
+
+    if (paymentRow.amount !== amount) {
+      console.error('[training/confirm] amount mismatch', { expected: paymentRow.amount, received: amount })
+      return NextResponse.json({ success: false, error: '결제 금액이 일치하지 않습니다.' }, { status: 400 })
+    }
+
+    const secretKey = process.env.TOSS_SECRET_KEY
+    if (!secretKey) {
+      return NextResponse.json({ success: false, error: '결제 설정이 완료되지 않았습니다.' }, { status: 500 })
+    }
+
+    const tossResponse = await fetch('https://api.tosspayments.com/v1/payments/confirm', {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${secretKey}:`).toString('base64')}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ orderId, amount, paymentKey }),
+    })
+    const tossData = await tossResponse.json()
+
+    if (!tossResponse.ok) {
+      console.error('[training/confirm] toss confirm failed:', tossData)
+      await supabase
+        .from('training_order_payments')
+        .update({
+          status: 'failed',
+          failure_reason: tossData?.message ?? 'toss confirm failed',
+          raw: tossData,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', paymentRow.id)
+      return NextResponse.json(
+        { success: false, error: tossData?.message || '결제 승인에 실패했습니다.', code: tossData?.code },
+        { status: tossResponse.status },
+      )
+    }
+
+    const paidAt = new Date().toISOString()
+    await supabase
+      .from('training_order_payments')
+      .update({
+        status: 'paid',
+        pg_provider: 'toss',
+        payment_key: paymentKey,
+        paid_at: paidAt,
+        receipt_url: tossData?.receipt?.url ?? null,
+        raw: tossData,
+        updated_at: paidAt,
+      })
+      .eq('id', paymentRow.id)
+
+    const { data: order } = await supabase
+      .from('training_orders')
+      .select('id, order_no, total_amount, installment_months, customer_name, customer_email')
+      .eq('id', paymentRow.order_id)
+      .maybeSingle()
+
+    const { data: paidRows } = await supabase
+      .from('training_order_payments')
+      .select('amount')
+      .eq('order_id', paymentRow.order_id)
+      .eq('status', 'paid')
+
+    const paidAmount = (paidRows ?? []).reduce((sum, row) => sum + (row.amount as number), 0)
+    const isComplete = order ? paidAmount >= order.total_amount : false
+
+    await supabase
+      .from('training_orders')
+      .update({
+        paid_amount: paidAmount,
+        status: isComplete ? 'completed' : 'active',
+        updated_at: paidAt,
+      })
+      .eq('id', paymentRow.order_id)
+
+    return NextResponse.json({
+      success: true,
+      orderNo: order?.order_no ?? null,
+      sequence: paymentRow.sequence,
+      installmentMonths: order?.installment_months ?? 1,
+      paidAmount,
+      totalAmount: order?.total_amount ?? amount,
+      receiptUrl: tossData?.receipt?.url ?? null,
+    })
+  } catch (error) {
+    console.error('[training/confirm] unexpected error:', error)
+    return NextResponse.json({ success: false, error: '결제 처리 중 오류가 발생했습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -1,0 +1,363 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { ArrowRight, Check, CreditCard, Loader2, ShieldCheck } from 'lucide-react'
+import { Header } from '@/components/layout/Header'
+import { Footer } from '@/components/layout/Footer'
+import { TossCheckout } from '@/components/payments/TossCheckout'
+import { describePlan, formatKrw, type TrainingPlan, type TrainingProduct } from '@/lib/training-package'
+import { cn } from '@/lib/utils'
+
+type CheckoutSession = {
+  orderNo: string
+  pgOrderId: string
+  amount: number
+  totalAmount: number
+  installmentMonths: number
+  orderName: string
+  customerKey: string
+}
+
+const PROCESS = [
+  { title: '상담', body: '현재 상황과 목표를 확인하고 필요한 과정을 함께 정리합니다.' },
+  { title: '트레이닝', body: '전문 트레이닝 과정을 통해 실무에 필요한 기준까지 끌어올립니다.' },
+  { title: '실무 투입', body: '준비가 된 인원부터 실제 현장과 프로젝트에 투입됩니다.' },
+  { title: '활동 관리', body: '계약과 행정 절차, 이후 활동까지 매니지먼트가 함께 관리합니다.' },
+]
+
+function Field({
+  label,
+  required,
+  children,
+  help,
+}: {
+  label: string
+  required?: boolean
+  children: React.ReactNode
+  help?: string
+}) {
+  return (
+    <label className="block">
+      <span className="mb-2 block text-sm font-semibold text-zinc-950">
+        {label}
+        {required ? <span className="ml-1">*</span> : null}
+      </span>
+      {children}
+      {help ? <span className="mt-1.5 block text-xs leading-5 text-zinc-500">{help}</span> : null}
+    </label>
+  )
+}
+
+const inputClass =
+  'min-h-11 w-full border border-zinc-300 bg-white px-3 text-sm text-zinc-950 outline-none transition focus:border-zinc-950'
+
+export function TrainingClient({ product, plans }: { product: TrainingProduct | null; plans: TrainingPlan[] }) {
+  const [planCode, setPlanCode] = useState(plans[0]?.code ?? '')
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [phone, setPhone] = useState('')
+  const [nationality, setNationality] = useState('')
+  const [memo, setMemo] = useState('')
+  const [agreed, setAgreed] = useState(false)
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [session, setSession] = useState<CheckoutSession | null>(null)
+
+  const selected = useMemo(() => plans.find((plan) => plan.code === planCode) ?? null, [plans, planCode])
+
+  const origin = typeof window === 'undefined' ? 'https://grigoent.co.kr' : window.location.origin
+
+  const startCheckout = async () => {
+    if (!selected) {
+      setError('결제 방식을 선택해 주세요.')
+      return
+    }
+    setError(null)
+    setPending(true)
+    try {
+      const response = await fetch('/api/training/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          planCode,
+          name,
+          email,
+          phone,
+          nationality,
+          memo,
+          agreed,
+          preferredLang: 'ko',
+        }),
+      })
+      const data = await response.json()
+      if (!response.ok || !data.success) {
+        setError(data.error ?? '결제 준비에 실패했습니다.')
+        return
+      }
+      setSession(data as CheckoutSession)
+    } catch {
+      setError('네트워크 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  if (!product) {
+    return (
+      <>
+        <Header />
+        <main className="bg-white pt-16">
+          <div className="mx-auto max-w-3xl px-4 py-24 text-center sm:px-6 lg:px-8">
+            <h1 className="text-2xl font-bold text-zinc-950">현재 판매 중인 과정이 없습니다.</h1>
+            <p className="mt-3 text-sm text-zinc-600">잠시 후 다시 확인해 주세요.</p>
+          </div>
+        </main>
+        <Footer />
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="bg-white pt-16">
+        <section className="border-b border-zinc-800 bg-zinc-950 text-white">
+          <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 md:py-20 lg:px-8">
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-zinc-400">GRIGO Program</p>
+            <h1 className="mt-6 max-w-4xl text-4xl font-black leading-[1.1] tracking-normal [text-wrap:balance] [word-break:keep-all] sm:text-5xl lg:text-6xl">
+              {product.title}
+            </h1>
+            {product.subtitle ? (
+              <p className="mt-6 max-w-2xl text-base leading-7 text-zinc-300 [word-break:keep-all]">{product.subtitle}</p>
+            ) : null}
+            <div className="mt-10 flex flex-wrap gap-3">
+              {product.highlights.map((item) => (
+                <span key={item} className="border border-white/25 px-3 py-2 text-sm text-zinc-200">
+                  {item}
+                </span>
+              ))}
+            </div>
+            <a
+              href="#apply"
+              className="mt-10 inline-flex items-center gap-3 border border-white px-6 py-3 text-sm font-semibold text-white transition hover:bg-white hover:text-zinc-950"
+            >
+              결제하고 시작하기
+              <ArrowRight className="h-4 w-4" />
+            </a>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="grid gap-3 border-t border-zinc-300 pt-7 md:grid-cols-[80px_1fr]">
+            <div className="font-mono text-sm font-semibold text-zinc-500">01</div>
+            <div>
+              <h2 className="text-2xl font-bold tracking-tight text-zinc-950 [word-break:keep-all]">진행 방식</h2>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-600 [word-break:keep-all]">
+                {product.description}
+              </p>
+            </div>
+          </div>
+          <div className="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            {PROCESS.map((step, index) => (
+              <div key={step.title} className="border border-zinc-300 p-5">
+                <div className="font-mono text-xs font-semibold text-zinc-500">{String(index + 1).padStart(2, '0')}</div>
+                <h3 className="mt-3 text-lg font-bold text-zinc-950">{step.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-zinc-600 [word-break:keep-all]">{step.body}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section id="apply" className="border-t border-zinc-300 bg-zinc-50">
+          <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+            <div className="grid gap-3 md:grid-cols-[80px_1fr]">
+              <div className="font-mono text-sm font-semibold text-zinc-500">02</div>
+              <div>
+                <h2 className="text-2xl font-bold tracking-tight text-zinc-950 [word-break:keep-all]">결제 방식 선택</h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-600 [word-break:keep-all]">
+                  일시불과 분납 중 선택할 수 있습니다. 분납은 첫 회차를 지금 결제하고, 이후 회차는 매월 안내에 따라 결제합니다.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              {plans.map((plan) => {
+                const active = plan.code === planCode
+                return (
+                  <button
+                    key={plan.code}
+                    type="button"
+                    onClick={() => {
+                      setPlanCode(plan.code)
+                      setSession(null)
+                    }}
+                    className={cn(
+                      'flex flex-col border p-5 text-left transition',
+                      active ? 'border-zinc-950 bg-zinc-950 text-white' : 'border-zinc-300 bg-white hover:border-zinc-500',
+                    )}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-semibold">{plan.label}</span>
+                      {active ? <Check className="h-4 w-4" /> : null}
+                    </div>
+                    <span className="mt-4 text-2xl font-black tracking-tight">{formatKrw(plan.amount_per_charge)}</span>
+                    <span className={cn('mt-1 text-xs', active ? 'text-zinc-300' : 'text-zinc-500')}>
+                      {plan.installment_months > 1 ? `${plan.installment_months}회 결제` : '한 번에 결제'}
+                    </span>
+                    <span className={cn('mt-4 text-xs', active ? 'text-zinc-300' : 'text-zinc-500')}>
+                      총 {formatKrw(plan.total_amount)}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+
+            {selected ? (
+              <div className="mt-6 border border-zinc-300 bg-white p-5">
+                <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
+                  <span className="font-semibold text-zinc-950">{selected.label}</span>
+                  <span className="text-zinc-600">{describePlan(selected)}</span>
+                  <span className="text-zinc-600">총 결제 금액 {formatKrw(selected.total_amount)}</span>
+                  <span className="font-semibold text-zinc-950">
+                    지금 결제할 금액 {formatKrw(selected.amount_per_charge)}
+                  </span>
+                </div>
+              </div>
+            ) : null}
+
+            <div className="mt-12 grid gap-3 md:grid-cols-[80px_1fr]">
+              <div className="font-mono text-sm font-semibold text-zinc-500">03</div>
+              <div>
+                <h2 className="text-2xl font-bold tracking-tight text-zinc-950 [word-break:keep-all]">신청자 정보</h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-600 [word-break:keep-all]">
+                  결제 확인과 이후 안내에 사용됩니다.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-8 grid max-w-3xl gap-5">
+              <div className="grid gap-5 sm:grid-cols-2">
+                <Field label="이름" required>
+                  <input
+                    value={name}
+                    onChange={(event) => {
+                      setName(event.target.value)
+                      setSession(null)
+                    }}
+                    className={inputClass}
+                    placeholder="홍길동"
+                  />
+                </Field>
+                <Field label="이메일" required>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(event) => {
+                      setEmail(event.target.value)
+                      setSession(null)
+                    }}
+                    className={inputClass}
+                    placeholder="name@example.com"
+                  />
+                </Field>
+                <Field label="연락처">
+                  <input
+                    value={phone}
+                    onChange={(event) => setPhone(event.target.value)}
+                    className={inputClass}
+                    placeholder="010-0000-0000"
+                  />
+                </Field>
+                <Field label="국적">
+                  <input
+                    value={nationality}
+                    onChange={(event) => setNationality(event.target.value)}
+                    className={inputClass}
+                    placeholder="대한민국 / Japan / Russia"
+                  />
+                </Field>
+              </div>
+              <Field label="남기실 말씀" help="상담에서 미리 확인이 필요한 내용이 있으면 적어주세요.">
+                <textarea
+                  rows={3}
+                  value={memo}
+                  onChange={(event) => setMemo(event.target.value)}
+                  className="w-full resize-none border border-zinc-300 bg-white px-3 py-2.5 text-sm text-zinc-950 outline-none transition focus:border-zinc-950"
+                />
+              </Field>
+
+              <label className="flex items-start gap-3 border border-zinc-300 bg-white p-4">
+                <input
+                  type="checkbox"
+                  checked={agreed}
+                  onChange={(event) => {
+                    setAgreed(event.target.checked)
+                    setSession(null)
+                  }}
+                  className="mt-1 h-4 w-4"
+                />
+                <span className="text-sm leading-6 text-zinc-700 [word-break:keep-all]">
+                  결제 금액과 진행 방식을 확인했으며, 분납을 선택한 경우 남은 회차를 매월 결제한다는 점에 동의합니다.
+                </span>
+              </label>
+
+              {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+              {!session ? (
+                <button
+                  type="button"
+                  onClick={startCheckout}
+                  disabled={pending}
+                  className="inline-flex min-h-12 w-fit items-center gap-2 bg-zinc-950 px-6 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+                >
+                  {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <CreditCard className="h-4 w-4" />}
+                  {pending ? '준비 중…' : '결제 진행하기'}
+                </button>
+              ) : (
+                <div className="border border-zinc-950 bg-white p-5">
+                  <p className="text-sm font-semibold text-zinc-950">주문번호 {session.orderNo}</p>
+                  <p className="mt-1 text-sm text-zinc-600">
+                    {session.installmentMonths > 1
+                      ? `${session.installmentMonths}회 중 1회차 ${formatKrw(session.amount)}을 결제합니다.`
+                      : `${formatKrw(session.amount)}을 결제합니다.`}
+                  </p>
+                  <div className="mt-5">
+                    <TossCheckout
+                      amount={session.amount}
+                      orderId={session.pgOrderId}
+                      orderName={session.orderName}
+                      customerName={name}
+                      customerEmail={email}
+                      customerMobilePhone={phone}
+                      customerKey={session.customerKey}
+                      successUrl={`${origin}/training/success`}
+                      failUrl={`${origin}/training/fail`}
+                      submitLabel={`${formatKrw(session.amount)} 결제하기`}
+                      onError={(message) => setError(message)}
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setSession(null)}
+                    className="mt-4 text-sm text-zinc-500 underline underline-offset-4 hover:text-zinc-900"
+                  >
+                    정보 수정하기
+                  </button>
+                </div>
+              )}
+
+              <div className="flex items-start gap-2 text-xs leading-6 text-zinc-500 [word-break:keep-all]">
+                <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>
+                  결제는 토스페이먼츠를 통해 처리됩니다. 진행 경로와 필요한 범위는 상담 후 확정되며, 확정 전 변경이
+                  필요한 경우 안내드립니다.
+                </span>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/training/fail/FailClient.tsx
+++ b/src/app/training/fail/FailClient.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { XCircle } from 'lucide-react'
+import { Header } from '@/components/layout/Header'
+import { Footer } from '@/components/layout/Footer'
+
+export function FailClient() {
+  const params = useSearchParams()
+  const message = params.get('message')
+  const code = params.get('code')
+
+  return (
+    <>
+      <Header />
+      <main className="bg-white pt-16">
+        <div className="mx-auto max-w-2xl px-4 py-24 sm:px-6 lg:px-8">
+          <div className="border border-zinc-300 p-8">
+            <XCircle className="h-10 w-10 text-red-600" />
+            <h1 className="mt-5 text-2xl font-bold tracking-tight text-zinc-950">결제가 취소되었습니다.</h1>
+            <p className="mt-3 text-sm leading-6 text-zinc-600 [word-break:keep-all]">
+              {message ?? '결제가 완료되지 않았습니다. 다시 시도해 주세요.'}
+            </p>
+            {code ? <p className="mt-2 font-mono text-xs text-zinc-400">{code}</p> : null}
+            <Link
+              href="/training"
+              className="mt-8 inline-flex min-h-11 items-center bg-zinc-950 px-5 text-sm font-semibold text-white transition hover:bg-zinc-800"
+            >
+              다시 시도하기
+            </Link>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/training/fail/page.tsx
+++ b/src/app/training/fail/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import type { Metadata } from 'next'
+import { FailClient } from './FailClient'
+
+export const metadata: Metadata = {
+  title: '결제 실패 - 그리고 엔터테인먼트',
+  robots: { index: false, follow: false },
+}
+
+export default function TrainingFailPage() {
+  return (
+    <Suspense fallback={null}>
+      <FailClient />
+    </Suspense>
+  )
+}

--- a/src/app/training/page.tsx
+++ b/src/app/training/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next'
+import { createClient } from '@supabase/supabase-js'
+import { TrainingClient } from './TrainingClient'
+import { TRAINING_PRODUCT_SLUG, type TrainingPlan, type TrainingProduct } from '@/lib/training-package'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: '트레이닝 + 실무투입 패키지 - 그리고 엔터테인먼트',
+  description:
+    '전문 트레이닝과 실무 투입을 결합한 GRIGO 패키지입니다. 일시불과 3·4·5개월 분납 중 선택해 결제할 수 있습니다.',
+  alternates: { canonical: '/training' },
+  openGraph: {
+    title: '트레이닝 + 실무투입 패키지 - 그리고 엔터테인먼트',
+    description: '전문 트레이닝과 실무 투입을 결합한 GRIGO 패키지 결제 페이지입니다.',
+    url: 'https://grigoent.co.kr/training',
+    type: 'website',
+  },
+}
+
+export default async function TrainingPage() {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  )
+
+  const { data: productRow } = await supabase
+    .from('training_products')
+    .select('id, slug, title, subtitle, description, highlights, currency')
+    .eq('slug', TRAINING_PRODUCT_SLUG)
+    .eq('is_active', true)
+    .maybeSingle()
+
+  let plans: TrainingPlan[] = []
+  if (productRow) {
+    const { data: planRows } = await supabase
+      .from('training_price_plans')
+      .select('id, code, label, plan_type, installment_months, amount_per_charge, total_amount, currency, note, sort_order')
+      .eq('product_id', productRow.id)
+      .eq('is_active', true)
+      .order('sort_order', { ascending: true })
+    plans = (planRows ?? []) as unknown as TrainingPlan[]
+  }
+
+  const product = productRow
+    ? ({
+        ...productRow,
+        highlights: Array.isArray(productRow.highlights) ? (productRow.highlights as string[]) : [],
+      } as TrainingProduct)
+    : null
+
+  return <TrainingClient product={product} plans={plans} />
+}

--- a/src/app/training/success/SuccessClient.tsx
+++ b/src/app/training/success/SuccessClient.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { CheckCircle2, Loader2, XCircle } from 'lucide-react'
+import { Header } from '@/components/layout/Header'
+import { Footer } from '@/components/layout/Footer'
+import { formatKrw } from '@/lib/training-package'
+
+type Result = {
+  success: boolean
+  orderNo?: string | null
+  sequence?: number
+  installmentMonths?: number
+  paidAmount?: number
+  totalAmount?: number
+  receiptUrl?: string | null
+  error?: string
+}
+
+export function SuccessClient() {
+  const params = useSearchParams()
+  const [result, setResult] = useState<Result | null>(null)
+  const confirmed = useRef(false)
+
+  const paymentKey = params.get('paymentKey')
+  const orderId = params.get('orderId')
+  const amount = params.get('amount')
+
+  useEffect(() => {
+    if (confirmed.current) return
+    if (!paymentKey || !orderId || !amount) {
+      setResult({ success: false, error: '결제 정보가 확인되지 않았습니다.' })
+      return
+    }
+    confirmed.current = true
+    ;(async () => {
+      try {
+        const response = await fetch('/api/training/confirm', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ paymentKey, orderId, amount: Number(amount) }),
+        })
+        const data = (await response.json()) as Result
+        setResult(data)
+      } catch {
+        setResult({ success: false, error: '결제 확인 중 오류가 발생했습니다.' })
+      }
+    })()
+  }, [paymentKey, orderId, amount])
+
+  return (
+    <>
+      <Header />
+      <main className="bg-white pt-16">
+        <div className="mx-auto max-w-2xl px-4 py-24 sm:px-6 lg:px-8">
+          {!result ? (
+            <div className="flex flex-col items-center text-center">
+              <Loader2 className="h-10 w-10 animate-spin text-zinc-400" />
+              <p className="mt-4 text-sm text-zinc-600">결제를 확인하고 있습니다.</p>
+            </div>
+          ) : result.success ? (
+            <div className="border border-zinc-950 p-8">
+              <CheckCircle2 className="h-10 w-10 text-zinc-950" />
+              <h1 className="mt-5 text-2xl font-bold tracking-tight text-zinc-950">결제가 완료되었습니다.</h1>
+              <p className="mt-3 text-sm leading-6 text-zinc-600 [word-break:keep-all]">
+                담당자가 확인 후 진행 일정을 안내드립니다.
+              </p>
+              <dl className="mt-8 grid gap-3 border-t border-zinc-300 pt-6 text-sm">
+                <div className="flex justify-between gap-4">
+                  <dt className="text-zinc-500">주문번호</dt>
+                  <dd className="font-semibold text-zinc-950">{result.orderNo ?? '-'}</dd>
+                </div>
+                {result.installmentMonths && result.installmentMonths > 1 ? (
+                  <div className="flex justify-between gap-4">
+                    <dt className="text-zinc-500">결제 회차</dt>
+                    <dd className="font-semibold text-zinc-950">
+                      {result.sequence} / {result.installmentMonths}회
+                    </dd>
+                  </div>
+                ) : null}
+                <div className="flex justify-between gap-4">
+                  <dt className="text-zinc-500">결제 누계</dt>
+                  <dd className="font-semibold text-zinc-950">
+                    {formatKrw(result.paidAmount ?? 0)} / {formatKrw(result.totalAmount ?? 0)}
+                  </dd>
+                </div>
+              </dl>
+              <div className="mt-8 flex flex-wrap gap-3">
+                {result.receiptUrl ? (
+                  <a
+                    href={result.receiptUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex min-h-11 items-center border border-zinc-300 px-5 text-sm font-semibold text-zinc-950 transition hover:border-zinc-950"
+                  >
+                    영수증 보기
+                  </a>
+                ) : null}
+                <Link
+                  href="/"
+                  className="inline-flex min-h-11 items-center bg-zinc-950 px-5 text-sm font-semibold text-white transition hover:bg-zinc-800"
+                >
+                  홈으로
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <div className="border border-zinc-300 p-8">
+              <XCircle className="h-10 w-10 text-red-600" />
+              <h1 className="mt-5 text-2xl font-bold tracking-tight text-zinc-950">결제를 확인하지 못했습니다.</h1>
+              <p className="mt-3 text-sm leading-6 text-zinc-600 [word-break:keep-all]">
+                {result.error ?? '잠시 후 다시 시도해 주세요.'}
+              </p>
+              <p className="mt-3 text-sm leading-6 text-zinc-600 [word-break:keep-all]">
+                결제가 이루어졌는데 이 화면이 보이면 주문번호와 함께 문의해 주세요.
+              </p>
+              <Link
+                href="/training"
+                className="mt-8 inline-flex min-h-11 items-center bg-zinc-950 px-5 text-sm font-semibold text-white transition hover:bg-zinc-800"
+              >
+                다시 시도하기
+              </Link>
+            </div>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/training/success/page.tsx
+++ b/src/app/training/success/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import type { Metadata } from 'next'
+import { SuccessClient } from './SuccessClient'
+
+export const metadata: Metadata = {
+  title: '결제 완료 - 그리고 엔터테인먼트',
+  robots: { index: false, follow: false },
+}
+
+export default function TrainingSuccessPage() {
+  return (
+    <Suspense fallback={null}>
+      <SuccessClient />
+    </Suspense>
+  )
+}

--- a/src/components/payments/TossCheckout.tsx
+++ b/src/components/payments/TossCheckout.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useCallback, useEffect, useId, useState } from 'react'
+import { ANONYMOUS, loadTossPayments, type TossPaymentsWidgets } from '@tosspayments/tosspayments-sdk'
+import { Loader2 } from 'lucide-react'
+
+const clientKey = process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY
+
+export type TossCheckoutProps = {
+  amount: number
+  orderId: string
+  orderName: string
+  customerName: string
+  customerEmail: string
+  customerMobilePhone?: string
+  customerKey?: string
+  successUrl: string
+  failUrl: string
+  submitLabel: string
+  onError?: (message: string) => void
+}
+
+// modoo_app 결제위젯과 동일한 방식(@tosspayments/tosspayments-sdk)의 최소 구성.
+export function TossCheckout({
+  amount,
+  orderId,
+  orderName,
+  customerName,
+  customerEmail,
+  customerMobilePhone,
+  customerKey,
+  successUrl,
+  failUrl,
+  submitLabel,
+  onError,
+}: TossCheckoutProps) {
+  const instanceId = useId().replace(/:/g, '')
+  const methodId = `toss-method-${instanceId}`
+  const agreementId = `toss-agreement-${instanceId}`
+
+  const [widgets, setWidgets] = useState<TossPaymentsWidgets>()
+  const [ready, setReady] = useState(false)
+  const [requesting, setRequesting] = useState(false)
+
+  useEffect(() => {
+    let mounted = true
+    if (!clientKey) {
+      onError?.('결제 설정이 완료되지 않았습니다.')
+      return
+    }
+    ;(async () => {
+      try {
+        const toss = await loadTossPayments(clientKey)
+        const instance = toss.widgets({ customerKey: customerKey ?? ANONYMOUS })
+        if (mounted) setWidgets(instance)
+      } catch (error) {
+        console.error('[toss] load failed', error)
+        onError?.('결제 모듈을 불러오지 못했습니다.')
+      }
+    })()
+    return () => {
+      mounted = false
+    }
+  }, [customerKey, onError])
+
+  useEffect(() => {
+    if (!widgets) return
+    let mounted = true
+    ;(async () => {
+      try {
+        await widgets.setAmount({ currency: 'KRW', value: amount })
+        await Promise.all([
+          widgets.renderPaymentMethods({ selector: `#${methodId}`, variantKey: 'DEFAULT' }),
+          widgets.renderAgreement({ selector: `#${agreementId}`, variantKey: 'AGREEMENT' }),
+        ])
+        if (mounted) setReady(true)
+      } catch (error) {
+        console.error('[toss] render failed', error)
+        onError?.('결제 수단을 표시하지 못했습니다.')
+      }
+    })()
+    return () => {
+      mounted = false
+    }
+  }, [widgets, amount, methodId, agreementId, onError])
+
+  const requestPayment = useCallback(async () => {
+    if (!widgets || !ready || requesting) return
+    setRequesting(true)
+    try {
+      await widgets.requestPayment({
+        orderId,
+        orderName,
+        customerName,
+        customerEmail,
+        customerMobilePhone: customerMobilePhone || undefined,
+        successUrl,
+        failUrl,
+      })
+    } catch (error) {
+      console.error('[toss] requestPayment failed', error)
+      const message = error instanceof Error ? error.message : '결제 요청에 실패했습니다.'
+      onError?.(message)
+      setRequesting(false)
+    }
+  }, [
+    widgets,
+    ready,
+    requesting,
+    orderId,
+    orderName,
+    customerName,
+    customerEmail,
+    customerMobilePhone,
+    successUrl,
+    failUrl,
+    onError,
+  ])
+
+  return (
+    <div className="grid gap-4">
+      <div id={methodId} />
+      <div id={agreementId} />
+      <button
+        type="button"
+        onClick={requestPayment}
+        disabled={!ready || requesting}
+        className="inline-flex min-h-12 items-center justify-center gap-2 bg-zinc-950 px-6 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+      >
+        {(!ready || requesting) && <Loader2 className="h-4 w-4 animate-spin" />}
+        {requesting ? '결제창을 여는 중…' : submitLabel}
+      </button>
+    </div>
+  )
+}

--- a/src/lib/training-package.ts
+++ b/src/lib/training-package.ts
@@ -1,0 +1,64 @@
+// 트레이닝 + 실무투입 패키지 판매 공용 타입/헬퍼.
+// 상품·요금제 정본은 grigoent Supabase `training_products` / `training_price_plans` 이며,
+// 금액은 서버가 항상 DB 값으로 재계산한다 (클라이언트 값 신뢰 금지).
+
+export const TRAINING_PRODUCT_SLUG = 'training-and-placement'
+
+export type TrainingPlan = {
+  id: string
+  code: string
+  label: string
+  plan_type: 'onetime' | 'installment'
+  installment_months: number
+  amount_per_charge: number
+  total_amount: number
+  currency: string
+  note: string | null
+  sort_order: number
+}
+
+export type TrainingProduct = {
+  id: string
+  slug: string
+  title: string
+  subtitle: string | null
+  description: string | null
+  highlights: string[]
+  currency: string
+}
+
+export function formatKrw(value: number): string {
+  return `${value.toLocaleString('ko-KR')}원`
+}
+
+// 분납 회차 안내 문구 (예: "매월 1,400,000원 × 3회")
+export function describePlan(plan: TrainingPlan): string {
+  if (plan.plan_type === 'onetime') return `${formatKrw(plan.amount_per_charge)} 일시 결제`
+  return `매월 ${formatKrw(plan.amount_per_charge)} × ${plan.installment_months}회`
+}
+
+// 첫 회차 결제 금액 (일시불이면 전액).
+export function firstChargeAmount(plan: TrainingPlan): number {
+  return plan.amount_per_charge
+}
+
+// 주문번호: GRT-YYMMDD-XXXXXX (사람이 읽기 쉬운 형태)
+export function buildOrderNo(now: Date, random: string): string {
+  const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000)
+  const yy = String(kst.getUTCFullYear()).slice(2)
+  const mm = String(kst.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(kst.getUTCDate()).padStart(2, '0')
+  return `GRT-${yy}${mm}${dd}-${random.toUpperCase()}`
+}
+
+// 회차별 청구 예정일: 1회차는 결제일, 이후 매월 같은 날.
+export function buildDueDates(start: Date, months: number): string[] {
+  const dates: string[] = []
+  for (let i = 0; i < months; i += 1) {
+    const d = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + i, start.getUTCDate()))
+    // 말일 보정 (예: 1/31 + 1개월 → 2/28)
+    if (d.getUTCDate() !== start.getUTCDate()) d.setUTCDate(0)
+    dates.push(d.toISOString().slice(0, 10))
+  }
+  return dates
+}


### PR DESCRIPTION
## 내용

grigoent 홈페이지에서 '트레이닝 + 실무투입' 패키지를 카드로 결제할 수 있는 `/training` 페이지를 추가했다.

- 요금제: 일시불 400만원 / 3개월 140만원×3 / 4개월 110만원×4 / 5개월 90만원×5
- 결제: 토스페이먼츠 결제위젯 (modoo_app과 동일한 `@tosspayments/tosspayments-sdk` + confirm API 패턴)
- 분납은 1회차만 즉시 결제하고 나머지는 `training_order_payments`에 예정 상태로 적재
- 금액은 클라이언트 값을 신뢰하지 않고 서버가 DB 요금제에서 재산출, 승인 시 회차 금액과 대조
- `paymentKey`/`pg_order_id` 기준 멱등 처리

## 주의

현재 붙은 토스 키는 **테스트 키**다. GRIGO 법인 명의 라이브 키를 받으면 Vercel 환경변수만 교체하면 된다.

## 검증

- `npm run build` 통과 (`/training`, `/training/success`, `/training/fail` 생성 확인)
- 변경 파일 타입 오류 0건 (레포 기존 오류는 별개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)