### PR TITLE
feat(training): PayPal 결제 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.1.1",
+        "@paypal/react-paypal-js": "^10.2.1",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
@@ -1141,6 +1142,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@paypal/paypal-js": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-10.1.0.tgz",
+      "integrity": "sha512-OolzHD7lu2K03HApg+YyMtBsPnrVc+ASj1MzuH/mz7feHj5OnxYyLWQiCcCm4douJFJ6P19JW8+LzsAN4x3jHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "promise-polyfill": "^8.3.0"
+      }
+    },
+    "node_modules/@paypal/react-paypal-js": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-10.2.1.tgz",
+      "integrity": "sha512-2jsQ9DmRWun1XckwAdo+eJvJxSWCv0XbY2SYedRRTAEIymLIQzdxEOBtHEmKIx/Z97dODHfzhbSTcmw3J1teqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@paypal/paypal-js": "^10.1.0",
+        "@paypal/sdk-constants": "^1.0.122",
+        "server-only": "^0.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@paypal/sdk-constants": {
+      "version": "1.0.158",
+      "resolved": "https://registry.npmjs.org/@paypal/sdk-constants/-/sdk-constants-1.0.158.tgz",
+      "integrity": "sha512-OrX2kN4gsBl6fG1GS1ewsNk7TTqYmdtUMVaJ+wAzPhsv9M7dfni95WuJdt4pMALOo5ioZeJ05a16BUSca5IC+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hi-base32": "^0.5.0"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -5257,6 +5291,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hi-base32": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA==",
+      "license": "MIT"
+    },
     "node_modules/hsl-to-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
@@ -6960,6 +7000,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7361,6 +7407,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.1.1",
+    "@paypal/react-paypal-js": "^10.2.1",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",

--- a/src/app/api/training/paypal/capture-order/route.ts
+++ b/src/app/api/training/paypal/capture-order/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const PAYPAL_CLIENT_ID = process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID
+const PAYPAL_CLIENT_SECRET = process.env.PAYPAL_CLIENT_SECRET
+const IS_SANDBOX = process.env.NEXT_PUBLIC_PAYPAL_SANDBOX === 'true'
+const PAYPAL_API_URL = IS_SANDBOX ? 'https://api-m.sandbox.paypal.com' : 'https://api-m.paypal.com'
+
+function getSupabase() {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+}
+
+async function getAccessToken(): Promise<string> {
+  if (!PAYPAL_CLIENT_ID || !PAYPAL_CLIENT_SECRET) throw new Error('PayPal credentials not configured')
+  const auth = Buffer.from(`${PAYPAL_CLIENT_ID}:${PAYPAL_CLIENT_SECRET}`).toString('base64')
+  const response = await fetch(`${PAYPAL_API_URL}/v1/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Authorization: `Basic ${auth}` },
+    body: 'grant_type=client_credentials',
+  })
+  if (!response.ok) {
+    console.error('[training/paypal] auth failed:', await response.text())
+    throw new Error('Failed to authenticate with PayPal')
+  }
+  const data = await response.json()
+  return data.access_token as string
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { paypalOrderId, pgOrderId } = (await request.json()) as {
+      paypalOrderId?: string
+      pgOrderId?: string
+    }
+    if (!paypalOrderId || !pgOrderId) {
+      return NextResponse.json({ success: false, error: '결제 정보가 누락되었습니다.' }, { status: 400 })
+    }
+
+    const supabase = getSupabase()
+    const { data: paymentRow } = await supabase
+      .from('training_order_payments')
+      .select('id, order_id, sequence, amount, status')
+      .eq('pg_order_id', pgOrderId)
+      .maybeSingle()
+
+    if (!paymentRow) {
+      return NextResponse.json({ success: false, error: '주문을 찾을 수 없습니다.' }, { status: 404 })
+    }
+
+    // 멱등: 이미 승인된 회차면 그대로 성공 응답.
+    if (paymentRow.status === 'paid') {
+      const { data: paidOrder } = await supabase
+        .from('training_orders')
+        .select('order_no')
+        .eq('id', paymentRow.order_id)
+        .maybeSingle()
+      return NextResponse.json({ success: true, idempotent: true, orderNo: paidOrder?.order_no ?? null })
+    }
+
+    const accessToken = await getAccessToken()
+    const captureResponse = await fetch(`${PAYPAL_API_URL}/v2/checkout/orders/${paypalOrderId}/capture`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+    })
+    const captureData = await captureResponse.json()
+
+    if (!captureResponse.ok || captureData.status !== 'COMPLETED') {
+      console.error('[training/paypal] capture failed:', captureData)
+      await supabase
+        .from('training_order_payments')
+        .update({
+          status: 'failed',
+          failure_reason: captureData?.message ?? `paypal status ${captureData?.status ?? 'unknown'}`,
+          raw: captureData,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', paymentRow.id)
+      return NextResponse.json(
+        { success: false, error: 'PayPal 결제 승인에 실패했습니다.' },
+        { status: captureResponse.ok ? 400 : captureResponse.status },
+      )
+    }
+
+    const captureDetails = captureData.purchase_units?.[0]?.payments?.captures?.[0]
+    const paidAt = new Date().toISOString()
+
+    await supabase
+      .from('training_order_payments')
+      .update({
+        status: 'paid',
+        pg_provider: 'paypal',
+        payment_key: captureDetails?.id ?? captureData.id ?? null,
+        paid_at: paidAt,
+        raw: captureData,
+        updated_at: paidAt,
+      })
+      .eq('id', paymentRow.id)
+
+    const { data: order } = await supabase
+      .from('training_orders')
+      .select('id, order_no, total_amount, installment_months')
+      .eq('id', paymentRow.order_id)
+      .maybeSingle()
+
+    const { data: paidRows } = await supabase
+      .from('training_order_payments')
+      .select('amount')
+      .eq('order_id', paymentRow.order_id)
+      .eq('status', 'paid')
+
+    const paidAmount = (paidRows ?? []).reduce((sum, row) => sum + (row.amount as number), 0)
+    const isComplete = order ? paidAmount >= order.total_amount : false
+
+    await supabase
+      .from('training_orders')
+      .update({
+        pg_provider: 'paypal',
+        paid_amount: paidAmount,
+        status: isComplete ? 'completed' : 'active',
+        updated_at: paidAt,
+      })
+      .eq('id', paymentRow.order_id)
+
+    return NextResponse.json({
+      success: true,
+      orderNo: order?.order_no ?? null,
+      sequence: paymentRow.sequence,
+      installmentMonths: order?.installment_months ?? 1,
+      paidAmount,
+      totalAmount: order?.total_amount ?? paymentRow.amount,
+      paypalTransactionId: captureDetails?.id ?? null,
+    })
+  } catch (error) {
+    console.error('[training/paypal] capture error:', error)
+    return NextResponse.json({ success: false, error: '결제 처리 중 오류가 발생했습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/api/training/paypal/create-order/route.ts
+++ b/src/app/api/training/paypal/create-order/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+// munchpeek_goods / theinashop 의 PayPal 연동과 동일한 방식(Client Credentials → Orders v2).
+// 다만 금액은 클라이언트 값을 쓰지 않고 우리 DB의 회차 청구 레코드에서만 가져온다.
+
+const PAYPAL_CLIENT_ID = process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID
+const PAYPAL_CLIENT_SECRET = process.env.PAYPAL_CLIENT_SECRET
+const IS_SANDBOX = process.env.NEXT_PUBLIC_PAYPAL_SANDBOX === 'true'
+const PAYPAL_API_URL = IS_SANDBOX ? 'https://api-m.sandbox.paypal.com' : 'https://api-m.paypal.com'
+
+// KRW는 PayPal이 직접 지원하지 않아 USD로 환산해 청구한다.
+// 실제 환율은 운영에서 env로 조정한다 (기본값은 보수적으로 잡은 근사치).
+const KRW_TO_USD = Number(process.env.PAYPAL_KRW_TO_USD || '0.00075')
+
+function getSupabase() {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+}
+
+async function getAccessToken(): Promise<string> {
+  if (!PAYPAL_CLIENT_ID || !PAYPAL_CLIENT_SECRET) throw new Error('PayPal credentials not configured')
+  const auth = Buffer.from(`${PAYPAL_CLIENT_ID}:${PAYPAL_CLIENT_SECRET}`).toString('base64')
+  const response = await fetch(`${PAYPAL_API_URL}/v1/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded', Authorization: `Basic ${auth}` },
+    body: 'grant_type=client_credentials',
+  })
+  if (!response.ok) {
+    console.error('[training/paypal] auth failed:', await response.text())
+    throw new Error('Failed to authenticate with PayPal')
+  }
+  const data = await response.json()
+  return data.access_token as string
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { pgOrderId, description } = (await request.json()) as { pgOrderId?: string; description?: string }
+    if (!pgOrderId) {
+      return NextResponse.json({ success: false, error: '주문 정보가 누락되었습니다.' }, { status: 400 })
+    }
+    if (!PAYPAL_CLIENT_ID || !PAYPAL_CLIENT_SECRET) {
+      return NextResponse.json({ success: false, error: 'PayPal 설정이 완료되지 않았습니다.' }, { status: 500 })
+    }
+
+    const supabase = getSupabase()
+    const { data: paymentRow } = await supabase
+      .from('training_order_payments')
+      .select('id, amount, status')
+      .eq('pg_order_id', pgOrderId)
+      .maybeSingle()
+
+    if (!paymentRow) {
+      return NextResponse.json({ success: false, error: '주문을 찾을 수 없습니다.' }, { status: 404 })
+    }
+    if (paymentRow.status === 'paid') {
+      return NextResponse.json({ success: false, error: '이미 결제가 완료된 건입니다.' }, { status: 409 })
+    }
+
+    const usdAmount = Math.round((paymentRow.amount as number) * KRW_TO_USD * 100) / 100
+    if (!Number.isFinite(usdAmount) || usdAmount <= 0) {
+      return NextResponse.json({ success: false, error: '결제 금액을 계산하지 못했습니다.' }, { status: 500 })
+    }
+
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://grigoent.co.kr'
+    const accessToken = await getAccessToken()
+
+    const response = await fetch(`${PAYPAL_API_URL}/v2/checkout/orders`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+        'PayPal-Request-Id': pgOrderId,
+      },
+      body: JSON.stringify({
+        intent: 'CAPTURE',
+        purchase_units: [
+          {
+            reference_id: pgOrderId,
+            description: (description || 'GRIGO training package').slice(0, 127),
+            amount: { currency_code: 'USD', value: usdAmount.toFixed(2) },
+          },
+        ],
+        application_context: {
+          brand_name: 'GRIGO entertainment',
+          landing_page: 'NO_PREFERENCE',
+          user_action: 'PAY_NOW',
+          return_url: `${siteUrl}/training/success`,
+          cancel_url: `${siteUrl}/training/fail`,
+        },
+      }),
+    })
+
+    const paypalOrder = await response.json()
+    if (!response.ok) {
+      console.error('[training/paypal] create order failed:', paypalOrder)
+      return NextResponse.json({ success: false, error: 'PayPal 주문 생성에 실패했습니다.' }, { status: response.status })
+    }
+
+    await supabase
+      .from('training_order_payments')
+      .update({ pg_provider: 'paypal', updated_at: new Date().toISOString() })
+      .eq('id', paymentRow.id)
+
+    return NextResponse.json({ success: true, id: paypalOrder.id, status: paypalOrder.status, usdAmount })
+  } catch (error) {
+    console.error('[training/paypal] create order error:', error)
+    return NextResponse.json({ success: false, error: '요청 처리 중 오류가 발생했습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { ArrowRight, Check, CreditCard, Loader2, ShieldCheck } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { ArrowRight, Check, CreditCard, Globe, Loader2, ShieldCheck } from 'lucide-react'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
 import { TossCheckout } from '@/components/payments/TossCheckout'
+import { PayPalCheckout } from '@/components/payments/PayPalCheckout'
 import { describePlan, formatKrw, type TrainingPlan, type TrainingProduct } from '@/lib/training-package'
 import { cn } from '@/lib/utils'
 
@@ -51,8 +53,12 @@ function Field({
 const inputClass =
   'min-h-11 w-full border border-zinc-300 bg-white px-3 text-sm text-zinc-950 outline-none transition focus:border-zinc-950'
 
+type PaymentMethod = 'toss' | 'paypal'
+
 export function TrainingClient({ product, plans }: { product: TrainingProduct | null; plans: TrainingPlan[] }) {
+  const router = useRouter()
   const [planCode, setPlanCode] = useState(plans[0]?.code ?? '')
+  const [method, setMethod] = useState<PaymentMethod>('toss')
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [phone, setPhone] = useState('')
@@ -321,20 +327,71 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                       ? `${session.installmentMonths}회 중 1회차 ${formatKrw(session.amount)}을 결제합니다.`
                       : `${formatKrw(session.amount)}을 결제합니다.`}
                   </p>
+                  <div className="mt-5 grid gap-2 sm:grid-cols-2">
+                    {(
+                      [
+                        { value: 'toss' as const, label: '국내 결제 (토스페이먼츠)', desc: '카드 · 계좌이체 · 간편결제' },
+                        { value: 'paypal' as const, label: '해외 결제 (PayPal)', desc: '해외 카드 · PayPal 잔액' },
+                      ]
+                    ).map((option) => (
+                      <button
+                        key={option.value}
+                        type="button"
+                        onClick={() => {
+                          setMethod(option.value)
+                          setError(null)
+                        }}
+                        className={cn(
+                          'flex flex-col border p-4 text-left transition',
+                          method === option.value
+                            ? 'border-zinc-950 bg-zinc-950 text-white'
+                            : 'border-zinc-300 bg-white hover:border-zinc-500',
+                        )}
+                      >
+                        <span className="flex items-center gap-2 text-sm font-semibold">
+                          {option.value === 'paypal' ? <Globe className="h-4 w-4" /> : <CreditCard className="h-4 w-4" />}
+                          {option.label}
+                        </span>
+                        <span className={cn('mt-1 text-xs', method === option.value ? 'text-zinc-300' : 'text-zinc-500')}>
+                          {option.desc}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+
                   <div className="mt-5">
-                    <TossCheckout
-                      amount={session.amount}
-                      orderId={session.pgOrderId}
-                      orderName={session.orderName}
-                      customerName={name}
-                      customerEmail={email}
-                      customerMobilePhone={phone}
-                      customerKey={session.customerKey}
-                      successUrl={`${origin}/training/success`}
-                      failUrl={`${origin}/training/fail`}
-                      submitLabel={`${formatKrw(session.amount)} 결제하기`}
-                      onError={(message) => setError(message)}
-                    />
+                    {method === 'toss' ? (
+                      <TossCheckout
+                        amount={session.amount}
+                        orderId={session.pgOrderId}
+                        orderName={session.orderName}
+                        customerName={name}
+                        customerEmail={email}
+                        customerMobilePhone={phone}
+                        customerKey={session.customerKey}
+                        successUrl={`${origin}/training/success`}
+                        failUrl={`${origin}/training/fail`}
+                        submitLabel={`${formatKrw(session.amount)} 결제하기`}
+                        onError={(message) => setError(message)}
+                      />
+                    ) : (
+                      <PayPalCheckout
+                        pgOrderId={session.pgOrderId}
+                        orderName={session.orderName}
+                        onSuccess={(paid) => {
+                          const query = new URLSearchParams({
+                            provider: 'paypal',
+                            orderNo: paid.orderNo ?? session.orderNo,
+                            sequence: String(paid.sequence ?? 1),
+                            installmentMonths: String(session.installmentMonths),
+                            paidAmount: String(paid.paidAmount ?? session.amount),
+                            totalAmount: String(paid.totalAmount ?? session.totalAmount),
+                          })
+                          router.push(`/training/success?${query.toString()}`)
+                        }}
+                        onError={(message) => setError(message)}
+                      />
+                    )}
                   </div>
                   <button
                     type="button"
@@ -349,8 +406,8 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
               <div className="flex items-start gap-2 text-xs leading-6 text-zinc-500 [word-break:keep-all]">
                 <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
                 <span>
-                  결제는 토스페이먼츠를 통해 처리됩니다. 진행 경로와 필요한 범위는 상담 후 확정되며, 확정 전 변경이
-                  필요한 경우 안내드립니다.
+                  국내 결제는 토스페이먼츠, 해외 결제는 PayPal로 처리됩니다. PayPal은 원화 금액을 USD로 환산해
+                  청구합니다. 진행 경로와 필요한 범위는 상담 후 확정되며, 확정 전 변경이 필요한 경우 안내드립니다.
                 </span>
               </div>
             </div>

--- a/src/app/training/success/SuccessClient.tsx
+++ b/src/app/training/success/SuccessClient.tsx
@@ -27,9 +27,25 @@ export function SuccessClient() {
   const paymentKey = params.get('paymentKey')
   const orderId = params.get('orderId')
   const amount = params.get('amount')
+  const provider = params.get('provider')
 
   useEffect(() => {
     if (confirmed.current) return
+
+    // PayPal은 승인(capture)이 이미 끝난 뒤 결과값을 들고 돌아온다.
+    if (provider === 'paypal') {
+      confirmed.current = true
+      setResult({
+        success: true,
+        orderNo: params.get('orderNo'),
+        sequence: Number(params.get('sequence') ?? '1'),
+        installmentMonths: Number(params.get('installmentMonths') ?? '1'),
+        paidAmount: Number(params.get('paidAmount') ?? '0'),
+        totalAmount: Number(params.get('totalAmount') ?? '0'),
+      })
+      return
+    }
+
     if (!paymentKey || !orderId || !amount) {
       setResult({ success: false, error: '결제 정보가 확인되지 않았습니다.' })
       return
@@ -48,7 +64,7 @@ export function SuccessClient() {
         setResult({ success: false, error: '결제 확인 중 오류가 발생했습니다.' })
       }
     })()
-  }, [paymentKey, orderId, amount])
+  }, [paymentKey, orderId, amount, provider, params])
 
   return (
     <>

--- a/src/components/payments/PayPalCheckout.tsx
+++ b/src/components/payments/PayPalCheckout.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { useState } from 'react'
+import { PayPalButtons, PayPalScriptProvider, usePayPalScriptReducer } from '@paypal/react-paypal-js'
+import { Loader2 } from 'lucide-react'
+
+const clientId = process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID
+
+export type PayPalCheckoutProps = {
+  /** 우리 시스템의 회차 결제 식별자 (training_order_payments.pg_order_id) */
+  pgOrderId: string
+  orderName: string
+  onSuccess: (result: { orderNo: string | null; sequence?: number; paidAmount?: number; totalAmount?: number }) => void
+  onError?: (message: string) => void
+  onCancel?: () => void
+}
+
+function Inner({ pgOrderId, orderName, onSuccess, onError, onCancel }: PayPalCheckoutProps) {
+  const [{ isPending }] = usePayPalScriptReducer()
+  const [processing, setProcessing] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+
+  const createOrder = async (): Promise<string> => {
+    setMessage(null)
+    setProcessing(true)
+    try {
+      const response = await fetch('/api/training/paypal/create-order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pgOrderId, description: orderName }),
+      })
+      const data = await response.json()
+      if (!response.ok || !data.success) throw new Error(data.error || 'PayPal 주문 생성에 실패했습니다.')
+      return data.id as string
+    } catch (error) {
+      const text = error instanceof Error ? error.message : 'PayPal 주문 생성에 실패했습니다.'
+      setMessage(text)
+      onError?.(text)
+      throw error
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  const onApprove = async (data: { orderID: string }): Promise<void> => {
+    setMessage(null)
+    setProcessing(true)
+    try {
+      const response = await fetch('/api/training/paypal/capture-order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ paypalOrderId: data.orderID, pgOrderId }),
+      })
+      const result = await response.json()
+      if (!response.ok || !result.success) throw new Error(result.error || 'PayPal 결제 승인에 실패했습니다.')
+      onSuccess(result)
+    } catch (error) {
+      const text = error instanceof Error ? error.message : 'PayPal 결제 승인에 실패했습니다.'
+      setMessage(text)
+      onError?.(text)
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  if (isPending) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-8 text-sm text-zinc-500">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        PayPal 불러오는 중…
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {message ? <p className="mb-3 text-sm text-red-600">{message}</p> : null}
+      {processing ? <p className="mb-3 text-sm text-zinc-500">결제를 처리하고 있습니다…</p> : null}
+      <PayPalButtons
+        style={{ layout: 'vertical', color: 'gold', shape: 'rect', label: 'paypal', height: 48 }}
+        disabled={processing}
+        createOrder={createOrder}
+        onApprove={onApprove}
+        onError={() => {
+          const text = 'PayPal 결제에 실패했습니다. 다시 시도해 주세요.'
+          setMessage(text)
+          onError?.(text)
+        }}
+        onCancel={() => {
+          setMessage('결제가 취소되었습니다.')
+          onCancel?.()
+        }}
+      />
+      <p className="mt-3 text-center text-xs text-zinc-500">
+        해외 카드와 PayPal 잔액으로 결제할 수 있습니다. 원화 금액은 USD로 환산되어 청구됩니다.
+      </p>
+    </div>
+  )
+}
+
+export function PayPalCheckout(props: PayPalCheckoutProps) {
+  if (!clientId) {
+    return (
+      <div className="border border-amber-300 bg-amber-50 p-4 text-sm text-amber-800">
+        PayPal 설정이 아직 완료되지 않았습니다. 운영 키 등록 후 이용할 수 있습니다.
+      </div>
+    )
+  }
+  return (
+    <PayPalScriptProvider options={{ clientId, currency: 'USD', intent: 'capture' }}>
+      <Inner {...props} />
+    </PayPalScriptProvider>
+  )
+}


### PR DESCRIPTION
## 내용

`/training` 결제에 PayPal을 추가했다. 국내는 토스페이먼츠, 해외는 PayPal로 나눠 선택한다.

- `/api/training/paypal/create-order` — 회차 금액을 DB에서 읽어 USD 환산 후 PayPal Orders v2 생성
- `/api/training/paypal/capture-order` — capture 후 회차 확정, 이미 결제된 건은 멱등 응답
- 성공 페이지가 `provider=paypal` 복귀를 처리

munchpeek_goods / theinashop 의 기존 PayPal 연동을 그대로 가져오되, 금액은 클라이언트 값을 신뢰하지 않고 서버가 DB에서 다시 읽도록 바꿨다.

## 주의

현재 PayPal은 **샌드박스 키**다. 실제 결제는 GRIGO 계정 키를 받은 뒤 환경변수만 교체하면 된다.
환율은 `PAYPAL_KRW_TO_USD` 환경변수로 조정한다 (기본 0.00075).

## 검증

- `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)