### PR TITLE
feat(training): 결제번호 표현 + 다국어(ko/en/ja) + PayPal 원화 결제

### DIFF
--- a/src/app/api/training/paypal/create-order/route.ts
+++ b/src/app/api/training/paypal/create-order/route.ts
@@ -9,9 +9,11 @@ const PAYPAL_CLIENT_SECRET = process.env.PAYPAL_CLIENT_SECRET
 const IS_SANDBOX = process.env.NEXT_PUBLIC_PAYPAL_SANDBOX === 'true'
 const PAYPAL_API_URL = IS_SANDBOX ? 'https://api-m.sandbox.paypal.com' : 'https://api-m.paypal.com'
 
-// KRW는 PayPal이 직접 지원하지 않아 USD로 환산해 청구한다.
-// 실제 환율은 운영에서 env로 조정한다 (기본값은 보수적으로 잡은 근사치).
+// 결제 통화는 원화(KRW)가 원칙이다.
+// PayPal 계정이 KRW를 지원하지 않는 경우에만 USD 환산으로 자동 폴백한다.
 const KRW_TO_USD = Number(process.env.PAYPAL_KRW_TO_USD || '0.00075')
+// KRW는 소수점을 쓰지 않는 통화라 정수로 보내야 한다.
+const FORCE_USD = process.env.PAYPAL_FORCE_USD === 'true'
 
 function getSupabase() {
   return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
@@ -57,44 +59,61 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: '이미 결제가 완료된 건입니다.' }, { status: 409 })
     }
 
-    const usdAmount = Math.round((paymentRow.amount as number) * KRW_TO_USD * 100) / 100
-    if (!Number.isFinite(usdAmount) || usdAmount <= 0) {
+    const krwAmount = paymentRow.amount as number
+    const usdAmount = Math.round(krwAmount * KRW_TO_USD * 100) / 100
+    if (!Number.isFinite(krwAmount) || krwAmount <= 0) {
       return NextResponse.json({ success: false, error: '결제 금액을 계산하지 못했습니다.' }, { status: 500 })
     }
 
     const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://grigoent.co.kr'
     const accessToken = await getAccessToken()
 
-    const response = await fetch(`${PAYPAL_API_URL}/v2/checkout/orders`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-        'PayPal-Request-Id': pgOrderId,
-      },
-      body: JSON.stringify({
-        intent: 'CAPTURE',
-        purchase_units: [
-          {
-            reference_id: pgOrderId,
-            description: (description || 'GRIGO training package').slice(0, 127),
-            amount: { currency_code: 'USD', value: usdAmount.toFixed(2) },
-          },
-        ],
-        application_context: {
-          brand_name: 'GRIGO entertainment',
-          landing_page: 'NO_PREFERENCE',
-          user_action: 'PAY_NOW',
-          return_url: `${siteUrl}/training/success`,
-          cancel_url: `${siteUrl}/training/fail`,
+    const createWith = async (currency: 'KRW' | 'USD') => {
+      const value = currency === 'KRW' ? String(Math.round(krwAmount)) : usdAmount.toFixed(2)
+      const response = await fetch(`${PAYPAL_API_URL}/v2/checkout/orders`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+          'PayPal-Request-Id': `${pgOrderId}-${currency}`,
         },
-      }),
-    })
+        body: JSON.stringify({
+          intent: 'CAPTURE',
+          purchase_units: [
+            {
+              reference_id: pgOrderId,
+              description: (description || 'GRIGO training package').slice(0, 127),
+              amount: { currency_code: currency, value },
+            },
+          ],
+          application_context: {
+            brand_name: 'GRIGO entertainment',
+            landing_page: 'NO_PREFERENCE',
+            user_action: 'PAY_NOW',
+            return_url: `${siteUrl}/training/success`,
+            cancel_url: `${siteUrl}/training/fail`,
+          },
+        }),
+      })
+      return { response, body: await response.json() }
+    }
 
-    const paypalOrder = await response.json()
-    if (!response.ok) {
-      console.error('[training/paypal] create order failed:', paypalOrder)
-      return NextResponse.json({ success: false, error: 'PayPal 주문 생성에 실패했습니다.' }, { status: response.status })
+    let currency: 'KRW' | 'USD' = FORCE_USD ? 'USD' : 'KRW'
+    let attempt = await createWith(currency)
+
+    // 계정이 원화를 지원하지 않으면 USD 환산으로 한 번만 재시도한다.
+    if (!attempt.response.ok && currency === 'KRW') {
+      console.warn('[training/paypal] KRW rejected, retrying in USD:', attempt.body)
+      currency = 'USD'
+      attempt = await createWith(currency)
+    }
+
+    if (!attempt.response.ok) {
+      console.error('[training/paypal] create order failed:', attempt.body)
+      return NextResponse.json(
+        { success: false, error: 'PayPal 주문 생성에 실패했습니다.' },
+        { status: attempt.response.status },
+      )
     }
 
     await supabase
@@ -102,7 +121,13 @@ export async function POST(request: NextRequest) {
       .update({ pg_provider: 'paypal', updated_at: new Date().toISOString() })
       .eq('id', paymentRow.id)
 
-    return NextResponse.json({ success: true, id: paypalOrder.id, status: paypalOrder.status, usdAmount })
+    return NextResponse.json({
+      success: true,
+      id: attempt.body.id,
+      status: attempt.body.status,
+      currency,
+      chargedAmount: currency === 'KRW' ? Math.round(krwAmount) : usdAmount,
+    })
   } catch (error) {
     console.error('[training/paypal] create order error:', error)
     return NextResponse.json({ success: false, error: '요청 처리 중 오류가 발생했습니다.' }, { status: 500 })

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -7,7 +7,20 @@ import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
 import { TossCheckout } from '@/components/payments/TossCheckout'
 import { PayPalCheckout } from '@/components/payments/PayPalCheckout'
-import { describePlan, formatKrw, type TrainingPlan, type TrainingProduct } from '@/lib/training-package'
+import { useLanguage } from '@/contexts/LanguageContext'
+import {
+  TRAINING_COPY,
+  describePlan,
+  formatKrw,
+  planLabel,
+  productDescription,
+  productHighlights,
+  productSubtitle,
+  productTitle,
+  type TrainingLang,
+  type TrainingPlan,
+  type TrainingProduct,
+} from '@/lib/training-package'
 import { cn } from '@/lib/utils'
 
 type CheckoutSession = {
@@ -20,12 +33,7 @@ type CheckoutSession = {
   customerKey: string
 }
 
-const PROCESS = [
-  { title: '상담', body: '현재 상황과 목표를 확인하고 필요한 과정을 함께 정리합니다.' },
-  { title: '트레이닝', body: '전문 트레이닝 과정을 통해 실무에 필요한 기준까지 끌어올립니다.' },
-  { title: '실무 투입', body: '준비가 된 인원부터 실제 현장과 프로젝트에 투입됩니다.' },
-  { title: '활동 관리', body: '계약과 행정 절차, 이후 활동까지 매니지먼트가 함께 관리합니다.' },
-]
+type PaymentMethod = 'toss' | 'paypal'
 
 function Field({
   label,
@@ -53,10 +61,17 @@ function Field({
 const inputClass =
   'min-h-11 w-full border border-zinc-300 bg-white px-3 text-sm text-zinc-950 outline-none transition focus:border-zinc-950'
 
-type PaymentMethod = 'toss' | 'paypal'
+const LANG_LABEL: Record<TrainingLang, string> = { ko: '한국어', en: 'EN', ja: '日本語' }
 
 export function TrainingClient({ product, plans }: { product: TrainingProduct | null; plans: TrainingPlan[] }) {
   const router = useRouter()
+  // 사이트 전역 언어 상태를 그대로 쓴다 (헤더 언어 선택과 연동).
+  const { language, setLanguage } = useLanguage()
+  const lang = (['ko', 'en', 'ja'] as const).includes(language as TrainingLang)
+    ? (language as TrainingLang)
+    : 'ko'
+  const t = TRAINING_COPY[lang]
+
   const [planCode, setPlanCode] = useState(plans[0]?.code ?? '')
   const [method, setMethod] = useState<PaymentMethod>('toss')
   const [name, setName] = useState('')
@@ -70,12 +85,11 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
   const [session, setSession] = useState<CheckoutSession | null>(null)
 
   const selected = useMemo(() => plans.find((plan) => plan.code === planCode) ?? null, [plans, planCode])
-
   const origin = typeof window === 'undefined' ? 'https://grigoent.co.kr' : window.location.origin
 
   const startCheckout = async () => {
     if (!selected) {
-      setError('결제 방식을 선택해 주세요.')
+      setError(t.planTitle)
       return
     }
     setError(null)
@@ -84,29 +98,40 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
       const response = await fetch('/api/training/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          planCode,
-          name,
-          email,
-          phone,
-          nationality,
-          memo,
-          agreed,
-          preferredLang: 'ko',
-        }),
+        body: JSON.stringify({ planCode, name, email, phone, nationality, memo, agreed, preferredLang: lang }),
       })
       const data = await response.json()
       if (!response.ok || !data.success) {
-        setError(data.error ?? '결제 준비에 실패했습니다.')
+        setError(data.error ?? 'Failed to start the payment.')
         return
       }
       setSession(data as CheckoutSession)
     } catch {
-      setError('네트워크 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.')
+      setError('Network error. Please try again in a moment.')
     } finally {
       setPending(false)
     }
   }
+
+  const langToggle = (
+    <div className="flex gap-1">
+      {(['ko', 'en', 'ja'] as TrainingLang[]).map((value) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => setLanguage(value)}
+          className={cn(
+            'border px-3 py-1.5 text-xs font-semibold transition',
+            value === lang
+              ? 'border-white bg-white text-zinc-950'
+              : 'border-white/30 text-zinc-300 hover:border-white/70',
+          )}
+        >
+          {LANG_LABEL[value]}
+        </button>
+      ))}
+    </div>
+  )
 
   if (!product) {
     return (
@@ -114,8 +139,8 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
         <Header />
         <main className="bg-white pt-16">
           <div className="mx-auto max-w-3xl px-4 py-24 text-center sm:px-6 lg:px-8">
-            <h1 className="text-2xl font-bold text-zinc-950">현재 판매 중인 과정이 없습니다.</h1>
-            <p className="mt-3 text-sm text-zinc-600">잠시 후 다시 확인해 주세요.</p>
+            <h1 className="text-2xl font-bold text-zinc-950">{t.emptyTitle}</h1>
+            <p className="mt-3 text-sm text-zinc-600">{t.emptyBody}</p>
           </div>
         </main>
         <Footer />
@@ -123,21 +148,25 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
     )
   }
 
+  const subtitle = productSubtitle(product, lang)
+  const description = productDescription(product, lang)
+
   return (
     <>
       <Header />
-      <main className="bg-white pt-16">
+      <main className={cn('bg-white pt-16', lang === 'ko' && '[word-break:keep-all]')}>
         <section className="border-b border-zinc-800 bg-zinc-950 text-white">
           <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 md:py-20 lg:px-8">
-            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-zinc-400">GRIGO Program</p>
-            <h1 className="mt-6 max-w-4xl text-4xl font-black leading-[1.1] tracking-normal [text-wrap:balance] [word-break:keep-all] sm:text-5xl lg:text-6xl">
-              {product.title}
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-zinc-400">{t.eyebrow}</p>
+              {langToggle}
+            </div>
+            <h1 className="mt-6 max-w-4xl text-4xl font-black leading-[1.1] tracking-normal [text-wrap:balance] sm:text-5xl lg:text-6xl">
+              {productTitle(product, lang)}
             </h1>
-            {product.subtitle ? (
-              <p className="mt-6 max-w-2xl text-base leading-7 text-zinc-300 [word-break:keep-all]">{product.subtitle}</p>
-            ) : null}
+            {subtitle ? <p className="mt-6 max-w-2xl text-base leading-7 text-zinc-300">{subtitle}</p> : null}
             <div className="mt-10 flex flex-wrap gap-3">
-              {product.highlights.map((item) => (
+              {productHighlights(product, lang).map((item) => (
                 <span key={item} className="border border-white/25 px-3 py-2 text-sm text-zinc-200">
                   {item}
                 </span>
@@ -147,7 +176,7 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
               href="#apply"
               className="mt-10 inline-flex items-center gap-3 border border-white px-6 py-3 text-sm font-semibold text-white transition hover:bg-white hover:text-zinc-950"
             >
-              결제하고 시작하기
+              {t.heroCta}
               <ArrowRight className="h-4 w-4" />
             </a>
           </div>
@@ -157,18 +186,16 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
           <div className="grid gap-3 border-t border-zinc-300 pt-7 md:grid-cols-[80px_1fr]">
             <div className="font-mono text-sm font-semibold text-zinc-500">01</div>
             <div>
-              <h2 className="text-2xl font-bold tracking-tight text-zinc-950 [word-break:keep-all]">진행 방식</h2>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-600 [word-break:keep-all]">
-                {product.description}
-              </p>
+              <h2 className="text-2xl font-bold tracking-tight text-zinc-950">{t.processTitle}</h2>
+              {description ? <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-600">{description}</p> : null}
             </div>
           </div>
           <div className="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-            {PROCESS.map((step, index) => (
+            {t.process.map((step, index) => (
               <div key={step.title} className="border border-zinc-300 p-5">
                 <div className="font-mono text-xs font-semibold text-zinc-500">{String(index + 1).padStart(2, '0')}</div>
                 <h3 className="mt-3 text-lg font-bold text-zinc-950">{step.title}</h3>
-                <p className="mt-2 text-sm leading-6 text-zinc-600 [word-break:keep-all]">{step.body}</p>
+                <p className="mt-2 text-sm leading-6 text-zinc-600">{step.body}</p>
               </div>
             ))}
           </div>
@@ -179,10 +206,8 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
             <div className="grid gap-3 md:grid-cols-[80px_1fr]">
               <div className="font-mono text-sm font-semibold text-zinc-500">02</div>
               <div>
-                <h2 className="text-2xl font-bold tracking-tight text-zinc-950 [word-break:keep-all]">결제 방식 선택</h2>
-                <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-600 [word-break:keep-all]">
-                  일시불과 분납 중 선택할 수 있습니다. 분납은 첫 회차를 지금 결제하고, 이후 회차는 매월 안내에 따라 결제합니다.
-                </p>
+                <h2 className="text-2xl font-bold tracking-tight text-zinc-950">{t.planTitle}</h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-600">{t.planIntro}</p>
               </div>
             </div>
 
@@ -202,16 +227,18 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                       active ? 'border-zinc-950 bg-zinc-950 text-white' : 'border-zinc-300 bg-white hover:border-zinc-500',
                     )}
                   >
-                    <div className="flex items-center justify-between">
-                      <span className="text-sm font-semibold">{plan.label}</span>
-                      {active ? <Check className="h-4 w-4" /> : null}
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-semibold">{planLabel(plan, lang)}</span>
+                      {active ? <Check className="h-4 w-4 shrink-0" /> : null}
                     </div>
-                    <span className="mt-4 text-2xl font-black tracking-tight">{formatKrw(plan.amount_per_charge)}</span>
+                    <span className="mt-4 text-2xl font-black tracking-tight">
+                      {formatKrw(plan.amount_per_charge, lang)}
+                    </span>
                     <span className={cn('mt-1 text-xs', active ? 'text-zinc-300' : 'text-zinc-500')}>
-                      {plan.installment_months > 1 ? `${plan.installment_months}회 결제` : '한 번에 결제'}
+                      {plan.installment_months > 1 ? t.planTimes(plan.installment_months) : t.planOnce}
                     </span>
                     <span className={cn('mt-4 text-xs', active ? 'text-zinc-300' : 'text-zinc-500')}>
-                      총 {formatKrw(plan.total_amount)}
+                      {t.planTotal} {formatKrw(plan.total_amount, lang)}
                     </span>
                   </button>
                 )
@@ -221,11 +248,13 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
             {selected ? (
               <div className="mt-6 border border-zinc-300 bg-white p-5">
                 <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm">
-                  <span className="font-semibold text-zinc-950">{selected.label}</span>
-                  <span className="text-zinc-600">{describePlan(selected)}</span>
-                  <span className="text-zinc-600">총 결제 금액 {formatKrw(selected.total_amount)}</span>
+                  <span className="font-semibold text-zinc-950">{planLabel(selected, lang)}</span>
+                  <span className="text-zinc-600">{describePlan(selected, lang)}</span>
+                  <span className="text-zinc-600">
+                    {t.planTotal} {formatKrw(selected.total_amount, lang)}
+                  </span>
                   <span className="font-semibold text-zinc-950">
-                    지금 결제할 금액 {formatKrw(selected.amount_per_charge)}
+                    {t.planPayNow} {formatKrw(selected.amount_per_charge, lang)}
                   </span>
                 </div>
               </div>
@@ -234,16 +263,14 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
             <div className="mt-12 grid gap-3 md:grid-cols-[80px_1fr]">
               <div className="font-mono text-sm font-semibold text-zinc-500">03</div>
               <div>
-                <h2 className="text-2xl font-bold tracking-tight text-zinc-950 [word-break:keep-all]">신청자 정보</h2>
-                <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-600 [word-break:keep-all]">
-                  결제 확인과 이후 안내에 사용됩니다.
-                </p>
+                <h2 className="text-2xl font-bold tracking-tight text-zinc-950">{t.infoTitle}</h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-zinc-600">{t.infoIntro}</p>
               </div>
             </div>
 
             <div className="mt-8 grid max-w-3xl gap-5">
               <div className="grid gap-5 sm:grid-cols-2">
-                <Field label="이름" required>
+                <Field label={t.fieldName} required>
                   <input
                     value={name}
                     onChange={(event) => {
@@ -251,10 +278,9 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                       setSession(null)
                     }}
                     className={inputClass}
-                    placeholder="홍길동"
                   />
                 </Field>
-                <Field label="이메일" required>
+                <Field label={t.fieldEmail} required>
                   <input
                     type="email"
                     value={email}
@@ -266,24 +292,18 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                     placeholder="name@example.com"
                   />
                 </Field>
-                <Field label="연락처">
-                  <input
-                    value={phone}
-                    onChange={(event) => setPhone(event.target.value)}
-                    className={inputClass}
-                    placeholder="010-0000-0000"
-                  />
+                <Field label={t.fieldPhone}>
+                  <input value={phone} onChange={(event) => setPhone(event.target.value)} className={inputClass} />
                 </Field>
-                <Field label="국적">
+                <Field label={t.fieldNationality}>
                   <input
                     value={nationality}
                     onChange={(event) => setNationality(event.target.value)}
                     className={inputClass}
-                    placeholder="대한민국 / Japan / Russia"
                   />
                 </Field>
               </div>
-              <Field label="남기실 말씀" help="상담에서 미리 확인이 필요한 내용이 있으면 적어주세요.">
+              <Field label={t.fieldMemo} help={t.fieldMemoHelp}>
                 <textarea
                   rows={3}
                   value={memo}
@@ -302,9 +322,7 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                   }}
                   className="mt-1 h-4 w-4"
                 />
-                <span className="text-sm leading-6 text-zinc-700 [word-break:keep-all]">
-                  결제 금액과 진행 방식을 확인했으며, 분납을 선택한 경우 남은 회차를 매월 결제한다는 점에 동의합니다.
-                </span>
+                <span className="text-sm leading-6 text-zinc-700">{t.agree}</span>
               </label>
 
               {error ? <p className="text-sm text-red-600">{error}</p> : null}
@@ -317,21 +335,24 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                   className="inline-flex min-h-12 w-fit items-center gap-2 bg-zinc-950 px-6 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
                 >
                   {pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <CreditCard className="h-4 w-4" />}
-                  {pending ? '준비 중…' : '결제 진행하기'}
+                  {pending ? t.preparing : t.startCheckout}
                 </button>
               ) : (
                 <div className="border border-zinc-950 bg-white p-5">
-                  <p className="text-sm font-semibold text-zinc-950">주문번호 {session.orderNo}</p>
+                  <p className="text-sm font-semibold text-zinc-950">
+                    {t.paymentNo} {session.orderNo}
+                  </p>
                   <p className="mt-1 text-sm text-zinc-600">
                     {session.installmentMonths > 1
-                      ? `${session.installmentMonths}회 중 1회차 ${formatKrw(session.amount)}을 결제합니다.`
-                      : `${formatKrw(session.amount)}을 결제합니다.`}
+                      ? t.payInstallment(formatKrw(session.amount, lang), session.installmentMonths)
+                      : t.payOnce(formatKrw(session.amount, lang))}
                   </p>
+
                   <div className="mt-5 grid gap-2 sm:grid-cols-2">
                     {(
                       [
-                        { value: 'toss' as const, label: '국내 결제 (토스페이먼츠)', desc: '카드 · 계좌이체 · 간편결제' },
-                        { value: 'paypal' as const, label: '해외 결제 (PayPal)', desc: '해외 카드 · PayPal 잔액' },
+                        { value: 'toss' as const, label: t.methodDomestic, desc: t.methodDomesticDesc },
+                        { value: 'paypal' as const, label: t.methodOverseas, desc: t.methodOverseasDesc },
                       ]
                     ).map((option) => (
                       <button
@@ -371,13 +392,14 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                         customerKey={session.customerKey}
                         successUrl={`${origin}/training/success`}
                         failUrl={`${origin}/training/fail`}
-                        submitLabel={`${formatKrw(session.amount)} 결제하기`}
+                        submitLabel={t.paySubmit(formatKrw(session.amount, lang))}
                         onError={(message) => setError(message)}
                       />
                     ) : (
                       <PayPalCheckout
                         pgOrderId={session.pgOrderId}
                         orderName={session.orderName}
+                        lang={lang}
                         onSuccess={(paid) => {
                           const query = new URLSearchParams({
                             provider: 'paypal',
@@ -393,22 +415,26 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                       />
                     )}
                   </div>
+
                   <button
                     type="button"
                     onClick={() => setSession(null)}
                     className="mt-4 text-sm text-zinc-500 underline underline-offset-4 hover:text-zinc-900"
                   >
-                    정보 수정하기
+                    {t.editInfo}
                   </button>
                 </div>
               )}
 
-              <div className="flex items-start gap-2 text-xs leading-6 text-zinc-500 [word-break:keep-all]">
-                <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
-                <span>
-                  국내 결제는 토스페이먼츠, 해외 결제는 PayPal로 처리됩니다. PayPal은 원화 금액을 USD로 환산해
-                  청구합니다. 진행 경로와 필요한 범위는 상담 후 확정되며, 확정 전 변경이 필요한 경우 안내드립니다.
-                </span>
+              <div className="grid gap-2 text-xs leading-6 text-zinc-500">
+                <p className="flex items-start gap-2">
+                  <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
+                  {t.notice}
+                </p>
+                <p className="flex items-start gap-2">
+                  <Globe className="mt-0.5 h-4 w-4 shrink-0" />
+                  {t.currencyNotice}
+                </p>
               </div>
             </div>
           </div>

--- a/src/app/training/fail/FailClient.tsx
+++ b/src/app/training/fail/FailClient.tsx
@@ -5,29 +5,36 @@ import { useSearchParams } from 'next/navigation'
 import { XCircle } from 'lucide-react'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
+import { useLanguage } from '@/contexts/LanguageContext'
+import { TRAINING_COPY, type TrainingLang } from '@/lib/training-package'
 
 export function FailClient() {
   const params = useSearchParams()
+  const { language } = useLanguage()
+  const lang = (['ko', 'en', 'ja'] as const).includes(language as TrainingLang)
+    ? (language as TrainingLang)
+    : 'ko'
+  const t = TRAINING_COPY[lang]
+
   const message = params.get('message')
   const code = params.get('code')
 
   return (
     <>
       <Header />
-      <main className="bg-white pt-16">
+      <main className={lang === 'ko' ? 'bg-white pt-16 [word-break:keep-all]' : 'bg-white pt-16'}>
         <div className="mx-auto max-w-2xl px-4 py-24 sm:px-6 lg:px-8">
           <div className="border border-zinc-300 p-8">
             <XCircle className="h-10 w-10 text-red-600" />
-            <h1 className="mt-5 text-2xl font-bold tracking-tight text-zinc-950">결제가 취소되었습니다.</h1>
-            <p className="mt-3 text-sm leading-6 text-zinc-600 [word-break:keep-all]">
-              {message ?? '결제가 완료되지 않았습니다. 다시 시도해 주세요.'}
-            </p>
+            <h1 className="mt-5 text-2xl font-bold tracking-tight text-zinc-950">{t.failTitle}</h1>
+            <p className="mt-3 text-sm leading-6 text-zinc-600">{message ?? t.failBody}</p>
+            <p className="mt-3 text-sm leading-6 text-zinc-600">{t.failContact}</p>
             {code ? <p className="mt-2 font-mono text-xs text-zinc-400">{code}</p> : null}
             <Link
               href="/training"
               className="mt-8 inline-flex min-h-11 items-center bg-zinc-950 px-5 text-sm font-semibold text-white transition hover:bg-zinc-800"
             >
-              다시 시도하기
+              {t.retry}
             </Link>
           </div>
         </div>

--- a/src/app/training/page.tsx
+++ b/src/app/training/page.tsx
@@ -26,7 +26,7 @@ export default async function TrainingPage() {
 
   const { data: productRow } = await supabase
     .from('training_products')
-    .select('id, slug, title, subtitle, description, highlights, currency')
+    .select('id, slug, title, subtitle, description, highlights, currency, i18n')
     .eq('slug', TRAINING_PRODUCT_SLUG)
     .eq('is_active', true)
     .maybeSingle()
@@ -35,7 +35,7 @@ export default async function TrainingPage() {
   if (productRow) {
     const { data: planRows } = await supabase
       .from('training_price_plans')
-      .select('id, code, label, plan_type, installment_months, amount_per_charge, total_amount, currency, note, sort_order')
+      .select('id, code, label, plan_type, installment_months, amount_per_charge, total_amount, currency, note, sort_order, i18n')
       .eq('product_id', productRow.id)
       .eq('is_active', true)
       .order('sort_order', { ascending: true })

--- a/src/app/training/success/SuccessClient.tsx
+++ b/src/app/training/success/SuccessClient.tsx
@@ -6,7 +6,8 @@ import { useSearchParams } from 'next/navigation'
 import { CheckCircle2, Loader2, XCircle } from 'lucide-react'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
-import { formatKrw } from '@/lib/training-package'
+import { useLanguage } from '@/contexts/LanguageContext'
+import { TRAINING_COPY, formatKrw, type TrainingLang } from '@/lib/training-package'
 
 type Result = {
   success: boolean
@@ -21,6 +22,12 @@ type Result = {
 
 export function SuccessClient() {
   const params = useSearchParams()
+  const { language } = useLanguage()
+  const lang = (['ko', 'en', 'ja'] as const).includes(language as TrainingLang)
+    ? (language as TrainingLang)
+    : 'ko'
+  const t = TRAINING_COPY[lang]
+
   const [result, setResult] = useState<Result | null>(null)
   const confirmed = useRef(false)
 
@@ -47,7 +54,7 @@ export function SuccessClient() {
     }
 
     if (!paymentKey || !orderId || !amount) {
-      setResult({ success: false, error: '결제 정보가 확인되지 않았습니다.' })
+      setResult({ success: false })
       return
     }
     confirmed.current = true
@@ -61,7 +68,7 @@ export function SuccessClient() {
         const data = (await response.json()) as Result
         setResult(data)
       } catch {
-        setResult({ success: false, error: '결제 확인 중 오류가 발생했습니다.' })
+        setResult({ success: false })
       }
     })()
   }, [paymentKey, orderId, amount, provider, params])
@@ -69,37 +76,35 @@ export function SuccessClient() {
   return (
     <>
       <Header />
-      <main className="bg-white pt-16">
+      <main className={lang === 'ko' ? 'bg-white pt-16 [word-break:keep-all]' : 'bg-white pt-16'}>
         <div className="mx-auto max-w-2xl px-4 py-24 sm:px-6 lg:px-8">
           {!result ? (
             <div className="flex flex-col items-center text-center">
               <Loader2 className="h-10 w-10 animate-spin text-zinc-400" />
-              <p className="mt-4 text-sm text-zinc-600">결제를 확인하고 있습니다.</p>
+              <p className="mt-4 text-sm text-zinc-600">{t.successChecking}</p>
             </div>
           ) : result.success ? (
             <div className="border border-zinc-950 p-8">
               <CheckCircle2 className="h-10 w-10 text-zinc-950" />
-              <h1 className="mt-5 text-2xl font-bold tracking-tight text-zinc-950">결제가 완료되었습니다.</h1>
-              <p className="mt-3 text-sm leading-6 text-zinc-600 [word-break:keep-all]">
-                담당자가 확인 후 진행 일정을 안내드립니다.
-              </p>
+              <h1 className="mt-5 text-2xl font-bold tracking-tight text-zinc-950">{t.successTitle}</h1>
+              <p className="mt-3 text-sm leading-6 text-zinc-600">{t.successBody}</p>
               <dl className="mt-8 grid gap-3 border-t border-zinc-300 pt-6 text-sm">
                 <div className="flex justify-between gap-4">
-                  <dt className="text-zinc-500">주문번호</dt>
+                  <dt className="text-zinc-500">{t.paymentNo}</dt>
                   <dd className="font-semibold text-zinc-950">{result.orderNo ?? '-'}</dd>
                 </div>
                 {result.installmentMonths && result.installmentMonths > 1 ? (
                   <div className="flex justify-between gap-4">
-                    <dt className="text-zinc-500">결제 회차</dt>
+                    <dt className="text-zinc-500">{t.labelSequence}</dt>
                     <dd className="font-semibold text-zinc-950">
-                      {result.sequence} / {result.installmentMonths}회
+                      {result.sequence} / {result.installmentMonths}
                     </dd>
                   </div>
                 ) : null}
                 <div className="flex justify-between gap-4">
-                  <dt className="text-zinc-500">결제 누계</dt>
+                  <dt className="text-zinc-500">{t.labelPaidTotal}</dt>
                   <dd className="font-semibold text-zinc-950">
-                    {formatKrw(result.paidAmount ?? 0)} / {formatKrw(result.totalAmount ?? 0)}
+                    {formatKrw(result.paidAmount ?? 0, lang)} / {formatKrw(result.totalAmount ?? 0, lang)}
                   </dd>
                 </div>
               </dl>
@@ -111,32 +116,28 @@ export function SuccessClient() {
                     rel="noopener noreferrer"
                     className="inline-flex min-h-11 items-center border border-zinc-300 px-5 text-sm font-semibold text-zinc-950 transition hover:border-zinc-950"
                   >
-                    영수증 보기
+                    {t.receipt}
                   </a>
                 ) : null}
                 <Link
                   href="/"
                   className="inline-flex min-h-11 items-center bg-zinc-950 px-5 text-sm font-semibold text-white transition hover:bg-zinc-800"
                 >
-                  홈으로
+                  {t.home}
                 </Link>
               </div>
             </div>
           ) : (
             <div className="border border-zinc-300 p-8">
               <XCircle className="h-10 w-10 text-red-600" />
-              <h1 className="mt-5 text-2xl font-bold tracking-tight text-zinc-950">결제를 확인하지 못했습니다.</h1>
-              <p className="mt-3 text-sm leading-6 text-zinc-600 [word-break:keep-all]">
-                {result.error ?? '잠시 후 다시 시도해 주세요.'}
-              </p>
-              <p className="mt-3 text-sm leading-6 text-zinc-600 [word-break:keep-all]">
-                결제가 이루어졌는데 이 화면이 보이면 주문번호와 함께 문의해 주세요.
-              </p>
+              <h1 className="mt-5 text-2xl font-bold tracking-tight text-zinc-950">{t.confirmFailTitle}</h1>
+              <p className="mt-3 text-sm leading-6 text-zinc-600">{result.error ?? t.failBody}</p>
+              <p className="mt-3 text-sm leading-6 text-zinc-600">{t.failContact}</p>
               <Link
                 href="/training"
                 className="mt-8 inline-flex min-h-11 items-center bg-zinc-950 px-5 text-sm font-semibold text-white transition hover:bg-zinc-800"
               >
-                다시 시도하기
+                {t.retry}
               </Link>
             </div>
           )}

--- a/src/components/payments/PayPalCheckout.tsx
+++ b/src/components/payments/PayPalCheckout.tsx
@@ -3,6 +3,49 @@
 import { useState } from 'react'
 import { PayPalButtons, PayPalScriptProvider, usePayPalScriptReducer } from '@paypal/react-paypal-js'
 import { Loader2 } from 'lucide-react'
+import type { TrainingLang } from '@/lib/training-package'
+
+const COPY: Record<TrainingLang, {
+  loading: string
+  processing: string
+  createFailed: string
+  captureFailed: string
+  failed: string
+  cancelled: string
+  notice: string
+  notConfigured: string
+}> = {
+  ko: {
+    loading: 'PayPal 불러오는 중…',
+    processing: '결제를 처리하고 있습니다…',
+    createFailed: 'PayPal 주문 생성에 실패했습니다.',
+    captureFailed: 'PayPal 결제 승인에 실패했습니다.',
+    failed: 'PayPal 결제에 실패했습니다. 다시 시도해 주세요.',
+    cancelled: '결제가 취소되었습니다.',
+    notice: '해외 카드와 PayPal 잔액으로 결제할 수 있습니다. 결제 통화는 원화(KRW)입니다.',
+    notConfigured: 'PayPal 설정이 아직 완료되지 않았습니다. 운영 키 등록 후 이용할 수 있습니다.',
+  },
+  en: {
+    loading: 'Loading PayPal…',
+    processing: 'Processing your payment…',
+    createFailed: 'Could not create the PayPal order.',
+    captureFailed: 'Could not complete the PayPal payment.',
+    failed: 'The PayPal payment failed. Please try again.',
+    cancelled: 'The payment was cancelled.',
+    notice: 'You can pay with an international card or your PayPal balance. Payments are charged in Korean won (KRW).',
+    notConfigured: 'PayPal is not configured yet. It will be available once the live keys are added.',
+  },
+  ja: {
+    loading: 'PayPalを読み込んでいます…',
+    processing: '決済を処理しています…',
+    createFailed: 'PayPal注文の作成に失敗しました。',
+    captureFailed: 'PayPal決済の承認に失敗しました。',
+    failed: 'PayPal決済に失敗しました。もう一度お試しください。',
+    cancelled: '決済がキャンセルされました。',
+    notice: '海外カードとPayPal残高でお支払いいただけます。決済通貨は韓国ウォン(KRW)です。',
+    notConfigured: 'PayPalの設定がまだ完了していません。運用キー登録後にご利用いただけます。',
+  },
+}
 
 const clientId = process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID
 
@@ -10,12 +53,14 @@ export type PayPalCheckoutProps = {
   /** 우리 시스템의 회차 결제 식별자 (training_order_payments.pg_order_id) */
   pgOrderId: string
   orderName: string
+  lang?: TrainingLang
   onSuccess: (result: { orderNo: string | null; sequence?: number; paidAmount?: number; totalAmount?: number }) => void
   onError?: (message: string) => void
   onCancel?: () => void
 }
 
-function Inner({ pgOrderId, orderName, onSuccess, onError, onCancel }: PayPalCheckoutProps) {
+function Inner({ pgOrderId, orderName, lang = 'ko', onSuccess, onError, onCancel }: PayPalCheckoutProps) {
+  const c = COPY[lang]
   const [{ isPending }] = usePayPalScriptReducer()
   const [processing, setProcessing] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
@@ -30,10 +75,10 @@ function Inner({ pgOrderId, orderName, onSuccess, onError, onCancel }: PayPalChe
         body: JSON.stringify({ pgOrderId, description: orderName }),
       })
       const data = await response.json()
-      if (!response.ok || !data.success) throw new Error(data.error || 'PayPal 주문 생성에 실패했습니다.')
+      if (!response.ok || !data.success) throw new Error(data.error || c.createFailed)
       return data.id as string
     } catch (error) {
-      const text = error instanceof Error ? error.message : 'PayPal 주문 생성에 실패했습니다.'
+      const text = error instanceof Error ? error.message : c.createFailed
       setMessage(text)
       onError?.(text)
       throw error
@@ -52,10 +97,10 @@ function Inner({ pgOrderId, orderName, onSuccess, onError, onCancel }: PayPalChe
         body: JSON.stringify({ paypalOrderId: data.orderID, pgOrderId }),
       })
       const result = await response.json()
-      if (!response.ok || !result.success) throw new Error(result.error || 'PayPal 결제 승인에 실패했습니다.')
+      if (!response.ok || !result.success) throw new Error(result.error || c.captureFailed)
       onSuccess(result)
     } catch (error) {
-      const text = error instanceof Error ? error.message : 'PayPal 결제 승인에 실패했습니다.'
+      const text = error instanceof Error ? error.message : c.captureFailed
       setMessage(text)
       onError?.(text)
     } finally {
@@ -67,7 +112,7 @@ function Inner({ pgOrderId, orderName, onSuccess, onError, onCancel }: PayPalChe
     return (
       <div className="flex items-center justify-center gap-2 py-8 text-sm text-zinc-500">
         <Loader2 className="h-4 w-4 animate-spin" />
-        PayPal 불러오는 중…
+        {c.loading}
       </div>
     )
   }
@@ -75,24 +120,24 @@ function Inner({ pgOrderId, orderName, onSuccess, onError, onCancel }: PayPalChe
   return (
     <div>
       {message ? <p className="mb-3 text-sm text-red-600">{message}</p> : null}
-      {processing ? <p className="mb-3 text-sm text-zinc-500">결제를 처리하고 있습니다…</p> : null}
+      {processing ? <p className="mb-3 text-sm text-zinc-500">{c.processing}</p> : null}
       <PayPalButtons
         style={{ layout: 'vertical', color: 'gold', shape: 'rect', label: 'paypal', height: 48 }}
         disabled={processing}
         createOrder={createOrder}
         onApprove={onApprove}
         onError={() => {
-          const text = 'PayPal 결제에 실패했습니다. 다시 시도해 주세요.'
+          const text = c.failed
           setMessage(text)
           onError?.(text)
         }}
         onCancel={() => {
-          setMessage('결제가 취소되었습니다.')
+          setMessage(c.cancelled)
           onCancel?.()
         }}
       />
       <p className="mt-3 text-center text-xs text-zinc-500">
-        해외 카드와 PayPal 잔액으로 결제할 수 있습니다. 원화 금액은 USD로 환산되어 청구됩니다.
+        {c.notice}
       </p>
     </div>
   )
@@ -102,12 +147,12 @@ export function PayPalCheckout(props: PayPalCheckoutProps) {
   if (!clientId) {
     return (
       <div className="border border-amber-300 bg-amber-50 p-4 text-sm text-amber-800">
-        PayPal 설정이 아직 완료되지 않았습니다. 운영 키 등록 후 이용할 수 있습니다.
+        {COPY[props.lang ?? 'ko'].notConfigured}
       </div>
     )
   }
   return (
-    <PayPalScriptProvider options={{ clientId, currency: 'USD', intent: 'capture' }}>
+    <PayPalScriptProvider options={{ clientId, currency: 'KRW', intent: 'capture' }}>
       <Inner {...props} />
     </PayPalScriptProvider>
   )

--- a/src/lib/training-package.ts
+++ b/src/lib/training-package.ts
@@ -1,8 +1,19 @@
 // 트레이닝 + 실무투입 패키지 판매 공용 타입/헬퍼.
 // 상품·요금제 정본은 grigoent Supabase `training_products` / `training_price_plans` 이며,
 // 금액은 서버가 항상 DB 값으로 재계산한다 (클라이언트 값 신뢰 금지).
+// 결제 통화는 언어와 무관하게 항상 원화(KRW)다.
 
 export const TRAINING_PRODUCT_SLUG = 'training-and-placement'
+
+export type TrainingLang = 'ko' | 'en' | 'ja'
+
+type PlanI18n = { label?: string; note?: string }
+type ProductI18n = {
+  title?: string
+  subtitle?: string
+  description?: string
+  highlights?: string[]
+}
 
 export type TrainingPlan = {
   id: string
@@ -15,6 +26,7 @@ export type TrainingPlan = {
   currency: string
   note: string | null
   sort_order: number
+  i18n?: Record<string, PlanI18n> | null
 }
 
 export type TrainingProduct = {
@@ -25,24 +37,61 @@ export type TrainingProduct = {
   description: string | null
   highlights: string[]
   currency: string
+  i18n?: Record<string, ProductI18n> | null
 }
 
-export function formatKrw(value: number): string {
-  return `${value.toLocaleString('ko-KR')}원`
+// 금액 표기는 언어별 표기만 다르고 통화는 항상 원화다.
+export function formatKrw(value: number, lang: TrainingLang = 'ko'): string {
+  const number = value.toLocaleString('ko-KR')
+  if (lang === 'en') return `KRW ${number}`
+  if (lang === 'ja') return `${number}ウォン`
+  return `${number}원`
 }
 
-// 분납 회차 안내 문구 (예: "매월 1,400,000원 × 3회")
-export function describePlan(plan: TrainingPlan): string {
-  if (plan.plan_type === 'onetime') return `${formatKrw(plan.amount_per_charge)} 일시 결제`
-  return `매월 ${formatKrw(plan.amount_per_charge)} × ${plan.installment_months}회`
+export function planLabel(plan: TrainingPlan, lang: TrainingLang): string {
+  if (lang === 'ko') return plan.label
+  return plan.i18n?.[lang]?.label || plan.label
 }
 
-// 첫 회차 결제 금액 (일시불이면 전액).
-export function firstChargeAmount(plan: TrainingPlan): number {
-  return plan.amount_per_charge
+export function planNote(plan: TrainingPlan, lang: TrainingLang): string | null {
+  if (lang === 'ko') return plan.note
+  return plan.i18n?.[lang]?.note ?? plan.note
 }
 
-// 주문번호: GRT-YYMMDD-XXXXXX (사람이 읽기 쉬운 형태)
+export function productTitle(product: TrainingProduct, lang: TrainingLang): string {
+  if (lang === 'ko') return product.title
+  return product.i18n?.[lang]?.title || product.title
+}
+
+export function productSubtitle(product: TrainingProduct, lang: TrainingLang): string | null {
+  if (lang === 'ko') return product.subtitle
+  return product.i18n?.[lang]?.subtitle ?? product.subtitle
+}
+
+export function productDescription(product: TrainingProduct, lang: TrainingLang): string | null {
+  if (lang === 'ko') return product.description
+  return product.i18n?.[lang]?.description ?? product.description
+}
+
+export function productHighlights(product: TrainingProduct, lang: TrainingLang): string[] {
+  if (lang === 'ko') return product.highlights
+  const translated = product.i18n?.[lang]?.highlights
+  return Array.isArray(translated) && translated.length > 0 ? translated : product.highlights
+}
+
+export function describePlan(plan: TrainingPlan, lang: TrainingLang): string {
+  const amount = formatKrw(plan.amount_per_charge, lang)
+  if (plan.plan_type === 'onetime') {
+    if (lang === 'en') return `${amount} paid at once`
+    if (lang === 'ja') return `${amount}を一括でお支払い`
+    return `${amount} 일시 결제`
+  }
+  if (lang === 'en') return `${amount} per month x ${plan.installment_months}`
+  if (lang === 'ja') return `毎月${amount} × ${plan.installment_months}回`
+  return `매월 ${amount} × ${plan.installment_months}회`
+}
+
+// 결제번호: GRT-YYMMDD-XXXXXX (사람이 읽기 쉬운 형태)
 export function buildOrderNo(now: Date, random: string): string {
   const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000)
   const yy = String(kst.getUTCFullYear()).slice(2)
@@ -61,4 +110,222 @@ export function buildDueDates(start: Date, months: number): string[] {
     dates.push(d.toISOString().slice(0, 10))
   }
   return dates
+}
+
+// 판매 페이지 정적 카피 (한국어 정본 + 영어/일본어).
+export const TRAINING_COPY: Record<TrainingLang, {
+  eyebrow: string
+  heroCta: string
+  processTitle: string
+  process: { title: string; body: string }[]
+  planTitle: string
+  planIntro: string
+  planOnce: string
+  planTimes: (n: number) => string
+  planTotal: string
+  planPayNow: string
+  infoTitle: string
+  infoIntro: string
+  fieldName: string
+  fieldEmail: string
+  fieldPhone: string
+  fieldNationality: string
+  fieldMemo: string
+  fieldMemoHelp: string
+  agree: string
+  startCheckout: string
+  preparing: string
+  paymentNo: string
+  payOnce: (amount: string) => string
+  payInstallment: (amount: string, months: number) => string
+  methodDomestic: string
+  methodDomesticDesc: string
+  methodOverseas: string
+  methodOverseasDesc: string
+  paySubmit: (amount: string) => string
+  editInfo: string
+  notice: string
+  emptyTitle: string
+  emptyBody: string
+  successTitle: string
+  successBody: string
+  successChecking: string
+  labelSequence: string
+  labelPaidTotal: string
+  receipt: string
+  home: string
+  failTitle: string
+  failBody: string
+  failContact: string
+  retry: string
+  confirmFailTitle: string
+  currencyNotice: string
+}> = {
+  ko: {
+    eyebrow: 'GRIGO PROGRAM',
+    heroCta: '결제하고 시작하기',
+    processTitle: '진행 방식',
+    process: [
+      { title: '상담', body: '현재 상황과 목표를 확인하고 필요한 과정을 함께 정리합니다.' },
+      { title: '트레이닝', body: '전문 트레이닝 과정을 통해 실무에 필요한 기준까지 끌어올립니다.' },
+      { title: '실무 투입', body: '준비가 된 인원부터 실제 현장과 프로젝트에 투입됩니다.' },
+      { title: '활동 관리', body: '계약과 행정 절차, 이후 활동까지 매니지먼트가 함께 관리합니다.' },
+    ],
+    planTitle: '결제 방식 선택',
+    planIntro:
+      '일시불과 분납 중 선택할 수 있습니다. 분납은 첫 회차를 지금 결제하고, 이후 회차는 매월 안내에 따라 결제합니다.',
+    planOnce: '한 번에 결제',
+    planTimes: (n) => `${n}회 결제`,
+    planTotal: '총',
+    planPayNow: '지금 결제할 금액',
+    infoTitle: '신청자 정보',
+    infoIntro: '결제 확인과 이후 안내에 사용됩니다.',
+    fieldName: '이름',
+    fieldEmail: '이메일',
+    fieldPhone: '연락처',
+    fieldNationality: '국적',
+    fieldMemo: '남기실 말씀',
+    fieldMemoHelp: '상담에서 미리 확인이 필요한 내용이 있으면 적어주세요.',
+    agree: '결제 금액과 진행 방식을 확인했으며, 분납을 선택한 경우 남은 회차를 매월 결제한다는 점에 동의합니다.',
+    startCheckout: '결제 진행하기',
+    preparing: '준비 중…',
+    paymentNo: '결제번호',
+    payOnce: (amount) => `${amount}을 결제합니다.`,
+    payInstallment: (amount, months) => `${months}회 중 1회차 ${amount}을 결제합니다.`,
+    methodDomestic: '국내 결제 (토스페이먼츠)',
+    methodDomesticDesc: '카드 · 계좌이체 · 간편결제',
+    methodOverseas: '해외 결제 (PayPal)',
+    methodOverseasDesc: '해외 카드 · PayPal 잔액',
+    paySubmit: (amount) => `${amount} 결제하기`,
+    editInfo: '정보 수정하기',
+    notice:
+      '국내 결제는 토스페이먼츠, 해외 결제는 PayPal로 처리됩니다. 진행 경로와 필요한 범위는 상담 후 확정되며, 확정 전 변경이 필요한 경우 안내드립니다.',
+    emptyTitle: '현재 판매 중인 과정이 없습니다.',
+    emptyBody: '잠시 후 다시 확인해 주세요.',
+    successTitle: '결제가 완료되었습니다.',
+    successBody: '담당자가 확인 후 진행 일정을 안내드립니다.',
+    successChecking: '결제를 확인하고 있습니다.',
+    labelSequence: '결제 회차',
+    labelPaidTotal: '결제 누계',
+    receipt: '영수증 보기',
+    home: '홈으로',
+    failTitle: '결제가 취소되었습니다.',
+    failBody: '결제가 완료되지 않았습니다. 다시 시도해 주세요.',
+    failContact: '결제가 이루어졌는데 이 화면이 보이면 결제번호와 함께 문의해 주세요.',
+    retry: '다시 시도하기',
+    confirmFailTitle: '결제를 확인하지 못했습니다.',
+    currencyNotice: '모든 결제는 원화(KRW)로 청구됩니다.',
+  },
+  en: {
+    eyebrow: 'GRIGO PROGRAM',
+    heroCta: 'Pay and get started',
+    processTitle: 'How it works',
+    process: [
+      { title: 'Consultation', body: 'We review your situation and goals, then map out what you actually need.' },
+      { title: 'Training', body: 'Professional training brings you up to the standard the field requires.' },
+      { title: 'Placement', body: 'Once you are ready, you go into real projects and real sets.' },
+      { title: 'Management', body: 'Contracts, paperwork, and your activity afterwards are managed with you.' },
+    ],
+    planTitle: 'Choose how you pay',
+    planIntro:
+      'You can pay in full or in monthly instalments. With an instalment plan you pay the first charge now, and the remaining charges monthly as we guide you.',
+    planOnce: 'Paid at once',
+    planTimes: (n) => `${n} payments`,
+    planTotal: 'Total',
+    planPayNow: 'Due now',
+    infoTitle: 'Your details',
+    infoIntro: 'Used to confirm your payment and to contact you afterwards.',
+    fieldName: 'Name',
+    fieldEmail: 'Email',
+    fieldPhone: 'Phone',
+    fieldNationality: 'Nationality',
+    fieldMemo: 'Anything you want to tell us',
+    fieldMemoHelp: 'Write anything you would like us to check before the consultation.',
+    agree:
+      'I have reviewed the amount and how the programme runs, and I agree to pay the remaining charges monthly if I chose an instalment plan.',
+    startCheckout: 'Continue to payment',
+    preparing: 'Preparing…',
+    paymentNo: 'Payment number',
+    payOnce: (amount) => `You are paying ${amount}.`,
+    payInstallment: (amount, months) => `You are paying ${amount}, the 1st of ${months} charges.`,
+    methodDomestic: 'Korean payment (Toss Payments)',
+    methodDomesticDesc: 'Card · bank transfer · local wallets',
+    methodOverseas: 'International payment (PayPal)',
+    methodOverseasDesc: 'International cards · PayPal balance',
+    paySubmit: (amount) => `Pay ${amount}`,
+    editInfo: 'Edit my details',
+    notice:
+      'Korean payments are processed by Toss Payments and international payments by PayPal. The route and scope are confirmed after your consultation, and we will let you know if anything needs to change.',
+    emptyTitle: 'No programme is on sale right now.',
+    emptyBody: 'Please check again shortly.',
+    successTitle: 'Your payment is complete.',
+    successBody: 'Our team will confirm it and share the schedule with you.',
+    successChecking: 'Confirming your payment.',
+    labelSequence: 'Charge',
+    labelPaidTotal: 'Paid so far',
+    receipt: 'View receipt',
+    home: 'Go to home',
+    failTitle: 'The payment was cancelled.',
+    failBody: 'The payment did not go through. Please try again.',
+    failContact: 'If you were charged but still see this screen, contact us with your payment number.',
+    retry: 'Try again',
+    confirmFailTitle: 'We could not confirm your payment.',
+    currencyNotice: 'All payments are charged in Korean won (KRW).',
+  },
+  ja: {
+    eyebrow: 'GRIGO PROGRAM',
+    heroCta: '決済して始める',
+    processTitle: '進行の流れ',
+    process: [
+      { title: '相談', body: '現在の状況と目標を確認し、必要な過程を一緒に整理します。' },
+      { title: 'トレーニング', body: '専門トレーニングで実務に必要な水準まで引き上げます。' },
+      { title: '実務投入', body: '準備ができた方から実際の現場とプロジェクトに参加します。' },
+      { title: '活動管理', body: '契約や行政手続き、その後の活動までマネジメントが一緒に管理します。' },
+    ],
+    planTitle: 'お支払い方法の選択',
+    planIntro:
+      '一括払いと分割払いから選べます。分割払いは初回分を今お支払いいただき、残りの回は毎月ご案内に沿ってお支払いいただきます。',
+    planOnce: '一括でお支払い',
+    planTimes: (n) => `${n}回払い`,
+    planTotal: '合計',
+    planPayNow: '今回のお支払い金額',
+    infoTitle: 'お申し込み情報',
+    infoIntro: '決済確認とその後のご案内に使用します。',
+    fieldName: 'お名前',
+    fieldEmail: 'メールアドレス',
+    fieldPhone: '連絡先',
+    fieldNationality: '国籍',
+    fieldMemo: 'ご要望・ご質問',
+    fieldMemoHelp: '相談前に確認しておきたい内容があればご記入ください。',
+    agree:
+      '金額と進行方法を確認しました。分割払いを選んだ場合、残りの回を毎月お支払いすることに同意します。',
+    startCheckout: '決済に進む',
+    preparing: '準備中…',
+    paymentNo: '決済番号',
+    payOnce: (amount) => `${amount}をお支払いいただきます。`,
+    payInstallment: (amount, months) => `${months}回のうち1回目の${amount}をお支払いいただきます。`,
+    methodDomestic: '韓国内決済 (トスペイメンツ)',
+    methodDomesticDesc: 'カード · 口座振替 · 簡単決済',
+    methodOverseas: '海外決済 (PayPal)',
+    methodOverseasDesc: '海外カード · PayPal残高',
+    paySubmit: (amount) => `${amount}を決済する`,
+    editInfo: '情報を修正する',
+    notice:
+      '韓国内決済はトスペイメンツ、海外決済はPayPalで処理されます。進行経路と必要な範囲は相談後に確定し、変更が必要な場合はご案内します。',
+    emptyTitle: '現在販売中の課程はありません。',
+    emptyBody: 'しばらくしてから再度ご確認ください。',
+    successTitle: '決済が完了しました。',
+    successBody: '担当者が確認のうえ、進行スケジュールをご案内します。',
+    successChecking: '決済を確認しています。',
+    labelSequence: '決済回次',
+    labelPaidTotal: '決済累計',
+    receipt: '領収書を見る',
+    home: 'ホームへ',
+    failTitle: '決済がキャンセルされました。',
+    failBody: '決済が完了しませんでした。もう一度お試しください。',
+    failContact: '決済されたのにこの画面が表示される場合は、決済番号を添えてお問い合わせください。',
+    retry: 'もう一度試す',
+    confirmFailTitle: '決済を確認できませんでした。',
+    currencyNotice: 'すべてのお支払いは韓国ウォン(KRW)で請求されます。',
+  },
 }


### PR DESCRIPTION
## 내용

- `주문번호` → **`결제번호`** 로 표현 변경 (결제 화면·성공·실패 전부)
- `/training`, `/training/success`, `/training/fail` 을 **한국어·영어·일본어**로 제공. 사이트 전역 언어 상태(`LanguageContext`)에 연동해 헤더 언어 선택과 함께 움직이고, 히어로에도 토글을 뒀다
- 상품명·부제·설명·하이라이트·요금제명은 DB `i18n` jsonb 로 관리 (migration `training_product_i18n`)
- **결제 통화는 언어와 무관하게 항상 원화(KRW)**. 금액 표기만 언어별로 바뀐다 (`4,000,000원` / `KRW 4,000,000` / `4,000,000ウォン`)
- PayPal도 KRW 로 주문을 만들고, 계정이 원화를 지원하지 않는 경우에만 USD 환산으로 한 번 폴백한다 (`PAYPAL_FORCE_USD` 로 강제 가능)

## 검증

- `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)