### PR TITLE
feat(training): 카드·계좌이체·PayPal 3수단 + 보수적 환율

### DIFF
--- a/src/app/api/training/checkout/route.ts
+++ b/src/app/api/training/checkout/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { randomBytes, randomUUID } from 'node:crypto'
 import { createClient } from '@supabase/supabase-js'
+import { foreignQuote } from '@/lib/paypal-fx'
 import {
   TRAINING_PRODUCT_SLUG,
   buildDueDates,
@@ -136,6 +137,8 @@ export async function POST(request: NextRequest) {
           ? `${product.title} (${plan.label} 1/${plan.installment_months}회차)`
           : `${product.title} (${plan.label})`,
       customerKey: order.billing_customer_key,
+      // PayPal은 원화를 지원하지 않아 외화로 청구된다. 사용자에게 미리 보여줄 견적.
+      paypalQuote: foreignQuote(plan.amount_per_charge),
     })
   } catch (error) {
     console.error('[training/checkout] unexpected error:', error)

--- a/src/app/api/training/paypal/create-order/route.ts
+++ b/src/app/api/training/paypal/create-order/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { PAYPAL_FOREIGN_CURRENCY, foreignQuote } from '@/lib/paypal-fx'
 
 // munchpeek_goods / theinashop 의 PayPal 연동과 동일한 방식(Client Credentials → Orders v2).
 // 다만 금액은 클라이언트 값을 쓰지 않고 우리 DB의 회차 청구 레코드에서만 가져온다.
@@ -9,11 +10,8 @@ const PAYPAL_CLIENT_SECRET = process.env.PAYPAL_CLIENT_SECRET
 const IS_SANDBOX = process.env.NEXT_PUBLIC_PAYPAL_SANDBOX === 'true'
 const PAYPAL_API_URL = IS_SANDBOX ? 'https://api-m.sandbox.paypal.com' : 'https://api-m.paypal.com'
 
-// 결제 통화는 원화(KRW)가 원칙이다.
-// PayPal 계정이 KRW를 지원하지 않는 경우에만 USD 환산으로 자동 폴백한다.
-const KRW_TO_USD = Number(process.env.PAYPAL_KRW_TO_USD || '0.00075')
-// KRW는 소수점을 쓰지 않는 통화라 정수로 보내야 한다.
-const FORCE_USD = process.env.PAYPAL_FORCE_USD === 'true'
+// 환산 정책은 src/lib/paypal-fx.ts 에 모아둔다 (checkout 응답의 견적과 동일한 값을 쓰기 위함).
+const FORCE_FOREIGN = process.env.PAYPAL_FORCE_USD === 'true'
 
 function getSupabase() {
   return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
@@ -60,16 +58,20 @@ export async function POST(request: NextRequest) {
     }
 
     const krwAmount = paymentRow.amount as number
-    const usdAmount = Math.round(krwAmount * KRW_TO_USD * 100) / 100
     if (!Number.isFinite(krwAmount) || krwAmount <= 0) {
       return NextResponse.json({ success: false, error: '결제 금액을 계산하지 못했습니다.' }, { status: 500 })
     }
+    const quote = foreignQuote(krwAmount)
+    if (!quote) {
+      return NextResponse.json({ success: false, error: '환율 설정을 확인해 주세요.' }, { status: 500 })
+    }
+    const foreignAmount = quote.amount
 
     const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://grigoent.co.kr'
     const accessToken = await getAccessToken()
 
-    const createWith = async (currency: 'KRW' | 'USD') => {
-      const value = currency === 'KRW' ? String(Math.round(krwAmount)) : usdAmount.toFixed(2)
+    const createWith = async (currency: string) => {
+      const value = currency === 'KRW' ? String(Math.round(krwAmount)) : foreignAmount.toFixed(2)
       const response = await fetch(`${PAYPAL_API_URL}/v2/checkout/orders`, {
         method: 'POST',
         headers: {
@@ -98,13 +100,13 @@ export async function POST(request: NextRequest) {
       return { response, body: await response.json() }
     }
 
-    let currency: 'KRW' | 'USD' = FORCE_USD ? 'USD' : 'KRW'
+    let currency = FORCE_FOREIGN ? PAYPAL_FOREIGN_CURRENCY : 'KRW'
     let attempt = await createWith(currency)
 
-    // 계정이 원화를 지원하지 않으면 USD 환산으로 한 번만 재시도한다.
+    // PayPal이 원화를 거절하면(CURRENCY_NOT_SUPPORTED) 외화 환산으로 한 번만 재시도한다.
     if (!attempt.response.ok && currency === 'KRW') {
-      console.warn('[training/paypal] KRW rejected, retrying in USD:', attempt.body)
-      currency = 'USD'
+      console.warn('[training/paypal] KRW rejected, retrying in foreign currency:', attempt.body)
+      currency = PAYPAL_FOREIGN_CURRENCY
       attempt = await createWith(currency)
     }
 
@@ -126,7 +128,9 @@ export async function POST(request: NextRequest) {
       id: attempt.body.id,
       status: attempt.body.status,
       currency,
-      chargedAmount: currency === 'KRW' ? Math.round(krwAmount) : usdAmount,
+      chargedAmount: currency === 'KRW' ? Math.round(krwAmount) : foreignAmount,
+      krwAmount,
+      appliedKrwPerUnit: currency === 'KRW' ? 1 : quote.krwPerUnit,
     })
   } catch (error) {
     console.error('[training/paypal] create order error:', error)

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -2,11 +2,12 @@
 
 import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { ArrowRight, Check, CreditCard, Globe, Loader2, ShieldCheck } from 'lucide-react'
+import { ArrowRight, Building2, Check, CreditCard, Globe, Loader2, ShieldCheck } from 'lucide-react'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
-import { TossCheckout } from '@/components/payments/TossCheckout'
+import { TossCheckout, type TossMethod } from '@/components/payments/TossCheckout'
 import { PayPalCheckout } from '@/components/payments/PayPalCheckout'
+import { formatForeign, type ForeignQuote } from '@/lib/paypal-fx'
 import { useLanguage } from '@/contexts/LanguageContext'
 import {
   TRAINING_COPY,
@@ -31,9 +32,10 @@ type CheckoutSession = {
   installmentMonths: number
   orderName: string
   customerKey: string
+  paypalQuote: ForeignQuote | null
 }
 
-type PaymentMethod = 'toss' | 'paypal'
+type PaymentMethod = 'card' | 'transfer' | 'paypal'
 
 function Field({
   label,
@@ -73,7 +75,7 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
   const t = TRAINING_COPY[lang]
 
   const [planCode, setPlanCode] = useState(plans[0]?.code ?? '')
-  const [method, setMethod] = useState<PaymentMethod>('toss')
+  const [method, setMethod] = useState<PaymentMethod>('card')
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [phone, setPhone] = useState('')
@@ -348,11 +350,12 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                       : t.payOnce(formatKrw(session.amount, lang))}
                   </p>
 
-                  <div className="mt-5 grid gap-2 sm:grid-cols-2">
+                  <div className="mt-5 grid gap-2 sm:grid-cols-3">
                     {(
                       [
-                        { value: 'toss' as const, label: t.methodDomestic, desc: t.methodDomesticDesc },
-                        { value: 'paypal' as const, label: t.methodOverseas, desc: t.methodOverseasDesc },
+                        { value: 'card' as const, label: t.methodCard, desc: t.methodCardDesc, Icon: CreditCard },
+                        { value: 'transfer' as const, label: t.methodTransfer, desc: t.methodTransferDesc, Icon: Building2 },
+                        { value: 'paypal' as const, label: t.methodOverseas, desc: t.methodOverseasDesc, Icon: Globe },
                       ]
                     ).map((option) => (
                       <button
@@ -370,7 +373,7 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                         )}
                       >
                         <span className="flex items-center gap-2 text-sm font-semibold">
-                          {option.value === 'paypal' ? <Globe className="h-4 w-4" /> : <CreditCard className="h-4 w-4" />}
+                          <option.Icon className="h-4 w-4 shrink-0" />
                           {option.label}
                         </span>
                         <span className={cn('mt-1 text-xs', method === option.value ? 'text-zinc-300' : 'text-zinc-500')}>
@@ -380,9 +383,19 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                     ))}
                   </div>
 
+                  {method === 'paypal' && session.paypalQuote ? (
+                    <p className="mt-4 border border-amber-300 bg-amber-50 p-4 text-xs leading-6 text-amber-900">
+                      {t.paypalCurrencyNotice(
+                        formatForeign(session.paypalQuote),
+                        formatKrw(session.amount, lang),
+                      )}
+                    </p>
+                  ) : null}
+
                   <div className="mt-5">
-                    {method === 'toss' ? (
+                    {method !== 'paypal' ? (
                       <TossCheckout
+                        method={(method === 'transfer' ? 'TRANSFER' : 'CARD') as TossMethod}
                         amount={session.amount}
                         orderId={session.pgOrderId}
                         orderName={session.orderName}
@@ -393,6 +406,7 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
                         successUrl={`${origin}/training/success`}
                         failUrl={`${origin}/training/fail`}
                         submitLabel={t.paySubmit(formatKrw(session.amount, lang))}
+                        lang={lang}
                         onError={(message) => setError(message)}
                       />
                     ) : (

--- a/src/components/payments/TossCheckout.tsx
+++ b/src/components/payments/TossCheckout.tsx
@@ -1,12 +1,34 @@
 'use client'
 
-import { useCallback, useEffect, useId, useState } from 'react'
-import { ANONYMOUS, loadTossPayments, type TossPaymentsWidgets } from '@tosspayments/tosspayments-sdk'
+import { useCallback, useState } from 'react'
+import { ANONYMOUS, loadTossPayments } from '@tosspayments/tosspayments-sdk'
 import { Loader2 } from 'lucide-react'
+import type { TrainingLang } from '@/lib/training-package'
 
 const clientKey = process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY
 
+export type TossMethod = 'CARD' | 'TRANSFER'
+
+const COPY: Record<TrainingLang, { opening: string; failed: string; notConfigured: string }> = {
+  ko: {
+    opening: '결제창을 여는 중…',
+    failed: '결제 요청에 실패했습니다.',
+    notConfigured: '결제 설정이 아직 완료되지 않았습니다.',
+  },
+  en: {
+    opening: 'Opening the payment window…',
+    failed: 'Could not start the payment.',
+    notConfigured: 'Payment is not configured yet.',
+  },
+  ja: {
+    opening: '決済画面を開いています…',
+    failed: '決済リクエストに失敗しました。',
+    notConfigured: '決済の設定がまだ完了していません。',
+  },
+}
+
 export type TossCheckoutProps = {
+  method: TossMethod
   amount: number
   orderId: string
   orderName: string
@@ -17,11 +39,14 @@ export type TossCheckoutProps = {
   successUrl: string
   failUrl: string
   submitLabel: string
+  lang?: TrainingLang
   onError?: (message: string) => void
 }
 
-// modoo_app 결제위젯과 동일한 방식(@tosspayments/tosspayments-sdk)의 최소 구성.
+// 결제수단을 화면에서 먼저 고르게 하고, 토스 결제창을 해당 수단으로 바로 연다.
+// (결제위젯 대신 requestPayment를 쓰면 카드/계좌이체를 명시적으로 분리할 수 있다)
 export function TossCheckout({
+  method,
   amount,
   orderId,
   orderName,
@@ -32,104 +57,77 @@ export function TossCheckout({
   successUrl,
   failUrl,
   submitLabel,
+  lang = 'ko',
   onError,
 }: TossCheckoutProps) {
-  const instanceId = useId().replace(/:/g, '')
-  const methodId = `toss-method-${instanceId}`
-  const agreementId = `toss-agreement-${instanceId}`
-
-  const [widgets, setWidgets] = useState<TossPaymentsWidgets>()
-  const [ready, setReady] = useState(false)
+  const c = COPY[lang]
   const [requesting, setRequesting] = useState(false)
 
-  useEffect(() => {
-    let mounted = true
+  const requestPayment = useCallback(async () => {
     if (!clientKey) {
-      onError?.('결제 설정이 완료되지 않았습니다.')
+      onError?.(c.notConfigured)
       return
     }
-    ;(async () => {
-      try {
-        const toss = await loadTossPayments(clientKey)
-        const instance = toss.widgets({ customerKey: customerKey ?? ANONYMOUS })
-        if (mounted) setWidgets(instance)
-      } catch (error) {
-        console.error('[toss] load failed', error)
-        onError?.('결제 모듈을 불러오지 못했습니다.')
-      }
-    })()
-    return () => {
-      mounted = false
-    }
-  }, [customerKey, onError])
-
-  useEffect(() => {
-    if (!widgets) return
-    let mounted = true
-    ;(async () => {
-      try {
-        await widgets.setAmount({ currency: 'KRW', value: amount })
-        await Promise.all([
-          widgets.renderPaymentMethods({ selector: `#${methodId}`, variantKey: 'DEFAULT' }),
-          widgets.renderAgreement({ selector: `#${agreementId}`, variantKey: 'AGREEMENT' }),
-        ])
-        if (mounted) setReady(true)
-      } catch (error) {
-        console.error('[toss] render failed', error)
-        onError?.('결제 수단을 표시하지 못했습니다.')
-      }
-    })()
-    return () => {
-      mounted = false
-    }
-  }, [widgets, amount, methodId, agreementId, onError])
-
-  const requestPayment = useCallback(async () => {
-    if (!widgets || !ready || requesting) return
+    if (requesting) return
     setRequesting(true)
     try {
-      await widgets.requestPayment({
+      const toss = await loadTossPayments(clientKey)
+      const payment = toss.payment({ customerKey: customerKey ?? ANONYMOUS })
+      const common = {
+        amount: { currency: 'KRW' as const, value: amount },
         orderId,
         orderName,
-        customerName,
-        customerEmail,
-        customerMobilePhone: customerMobilePhone || undefined,
         successUrl,
         failUrl,
-      })
+        customerName: customerName || undefined,
+        customerEmail: customerEmail || undefined,
+        customerMobilePhone: customerMobilePhone || undefined,
+      }
+      if (method === 'TRANSFER') {
+        await payment.requestPayment({
+          ...common,
+          method: 'TRANSFER',
+          transfer: { cashReceipt: { type: '소득공제' }, useEscrow: false },
+        })
+      } else {
+        await payment.requestPayment({
+          ...common,
+          method: 'CARD',
+          card: { useEscrow: false, flowMode: 'DEFAULT', useCardPoint: false, useAppCardOnly: false },
+        })
+      }
     } catch (error) {
       console.error('[toss] requestPayment failed', error)
-      const message = error instanceof Error ? error.message : '결제 요청에 실패했습니다.'
+      const message = error instanceof Error && error.message ? error.message : c.failed
       onError?.(message)
+    } finally {
       setRequesting(false)
     }
   }, [
-    widgets,
-    ready,
+    c,
     requesting,
+    method,
+    amount,
     orderId,
     orderName,
+    successUrl,
+    failUrl,
     customerName,
     customerEmail,
     customerMobilePhone,
-    successUrl,
-    failUrl,
+    customerKey,
     onError,
   ])
 
   return (
-    <div className="grid gap-4">
-      <div id={methodId} />
-      <div id={agreementId} />
-      <button
-        type="button"
-        onClick={requestPayment}
-        disabled={!ready || requesting}
-        className="inline-flex min-h-12 items-center justify-center gap-2 bg-zinc-950 px-6 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
-      >
-        {(!ready || requesting) && <Loader2 className="h-4 w-4 animate-spin" />}
-        {requesting ? '결제창을 여는 중…' : submitLabel}
-      </button>
-    </div>
+    <button
+      type="button"
+      onClick={requestPayment}
+      disabled={requesting}
+      className="inline-flex min-h-12 w-full items-center justify-center gap-2 bg-zinc-950 px-6 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:bg-zinc-400"
+    >
+      {requesting ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+      {requesting ? c.opening : submitLabel}
+    </button>
   )
 }

--- a/src/lib/paypal-fx.ts
+++ b/src/lib/paypal-fx.ts
@@ -1,0 +1,33 @@
+// PayPal 외화 환산 정책.
+//
+// 원칙은 원화(KRW) 결제지만 PayPal은 KRW를 지원하지 않는다(CURRENCY_NOT_SUPPORTED).
+// 그래서 외화로 청구하되, 환율은 항상 시장가보다 보수적으로(1단위당 원화를 적게) 잡아
+// 실제 수취 원화가 정가보다 적어지지 않게 한다.
+//
+// 예) 시장 1USD = 1,449원인데 1,350으로 잡으면
+//     400만원 → $2,963 → 시장 환산 약 4,293,000원 (정가 대비 +7%)
+//
+// 시장 환율이 PAYPAL_KRW_PER_USD 아래로 내려가면 손실이 발생하므로 주기적으로 점검한다.
+
+export const PAYPAL_FOREIGN_CURRENCY = (process.env.PAYPAL_FOREIGN_CURRENCY || 'USD').toUpperCase()
+export const PAYPAL_KRW_PER_UNIT = Number(process.env.PAYPAL_KRW_PER_USD || '1350')
+
+export type ForeignQuote = {
+  currency: string
+  amount: number
+  krwPerUnit: number
+  krwAmount: number
+}
+
+export function foreignQuote(krwAmount: number): ForeignQuote | null {
+  if (!Number.isFinite(krwAmount) || krwAmount <= 0) return null
+  if (!Number.isFinite(PAYPAL_KRW_PER_UNIT) || PAYPAL_KRW_PER_UNIT <= 0) return null
+  // 절상해서 원 단위 손실까지 제거한다.
+  const amount = Math.ceil(krwAmount / PAYPAL_KRW_PER_UNIT)
+  return { currency: PAYPAL_FOREIGN_CURRENCY, amount, krwPerUnit: PAYPAL_KRW_PER_UNIT, krwAmount }
+}
+
+export function formatForeign(quote: ForeignQuote): string {
+  const symbol = quote.currency === 'USD' ? '$' : ''
+  return `${symbol}${quote.amount.toLocaleString('en-US')}${symbol ? '' : ` ${quote.currency}`}`
+}

--- a/src/lib/training-package.ts
+++ b/src/lib/training-package.ts
@@ -138,10 +138,13 @@ export const TRAINING_COPY: Record<TrainingLang, {
   paymentNo: string
   payOnce: (amount: string) => string
   payInstallment: (amount: string, months: number) => string
-  methodDomestic: string
-  methodDomesticDesc: string
+  methodCard: string
+  methodCardDesc: string
+  methodTransfer: string
+  methodTransferDesc: string
   methodOverseas: string
   methodOverseasDesc: string
+  paypalCurrencyNotice: (foreign: string, krw: string) => string
   paySubmit: (amount: string) => string
   editInfo: string
   notice: string
@@ -192,14 +195,18 @@ export const TRAINING_COPY: Record<TrainingLang, {
     paymentNo: '결제번호',
     payOnce: (amount) => `${amount}을 결제합니다.`,
     payInstallment: (amount, months) => `${months}회 중 1회차 ${amount}을 결제합니다.`,
-    methodDomestic: '국내 결제 (토스페이먼츠)',
-    methodDomesticDesc: '카드 · 계좌이체 · 간편결제',
-    methodOverseas: '해외 결제 (PayPal)',
+    methodCard: '카드결제',
+    methodCardDesc: '국내외 신용·체크카드 (원화 결제)',
+    methodTransfer: '계좌이체',
+    methodTransferDesc: '국내 은행 실시간 계좌이체 (원화 결제)',
+    methodOverseas: 'PayPal',
     methodOverseasDesc: '해외 카드 · PayPal 잔액',
+    paypalCurrencyNotice: (foreign, krw) =>
+      `PayPal은 원화 결제를 지원하지 않아 ${foreign}로 청구됩니다. 기준 금액은 ${krw}이며, 환율 변동에 대비한 여유분이 포함되어 있습니다.`,
     paySubmit: (amount) => `${amount} 결제하기`,
     editInfo: '정보 수정하기',
     notice:
-      '국내 결제는 토스페이먼츠, 해외 결제는 PayPal로 처리됩니다. 진행 경로와 필요한 범위는 상담 후 확정되며, 확정 전 변경이 필요한 경우 안내드립니다.',
+      '카드결제와 계좌이체는 토스페이먼츠, PayPal은 PayPal에서 처리됩니다. 진행 경로와 필요한 범위는 상담 후 확정되며, 확정 전 변경이 필요한 경우 안내드립니다.',
     emptyTitle: '현재 판매 중인 과정이 없습니다.',
     emptyBody: '잠시 후 다시 확인해 주세요.',
     successTitle: '결제가 완료되었습니다.',
@@ -214,7 +221,7 @@ export const TRAINING_COPY: Record<TrainingLang, {
     failContact: '결제가 이루어졌는데 이 화면이 보이면 결제번호와 함께 문의해 주세요.',
     retry: '다시 시도하기',
     confirmFailTitle: '결제를 확인하지 못했습니다.',
-    currencyNotice: '모든 결제는 원화(KRW)로 청구됩니다.',
+    currencyNotice: '기본 결제 통화는 원화(KRW)입니다. PayPal만 원화를 지원하지 않아 외화로 청구됩니다.',
   },
   en: {
     eyebrow: 'GRIGO PROGRAM',
@@ -248,14 +255,18 @@ export const TRAINING_COPY: Record<TrainingLang, {
     paymentNo: 'Payment number',
     payOnce: (amount) => `You are paying ${amount}.`,
     payInstallment: (amount, months) => `You are paying ${amount}, the 1st of ${months} charges.`,
-    methodDomestic: 'Korean payment (Toss Payments)',
-    methodDomesticDesc: 'Card · bank transfer · local wallets',
-    methodOverseas: 'International payment (PayPal)',
+    methodCard: 'Card',
+    methodCardDesc: 'Korean and international cards, charged in KRW',
+    methodTransfer: 'Bank transfer',
+    methodTransferDesc: 'Real-time transfer from a Korean bank, charged in KRW',
+    methodOverseas: 'PayPal',
     methodOverseasDesc: 'International cards · PayPal balance',
+    paypalCurrencyNotice: (foreign, krw) =>
+      `PayPal cannot charge Korean won, so you will be billed ${foreign}. The base price is ${krw}, and the amount includes a buffer for exchange rate movement.`,
     paySubmit: (amount) => `Pay ${amount}`,
     editInfo: 'Edit my details',
     notice:
-      'Korean payments are processed by Toss Payments and international payments by PayPal. The route and scope are confirmed after your consultation, and we will let you know if anything needs to change.',
+      'Card and bank transfer are processed by Toss Payments, and PayPal is processed by PayPal. The route and scope are confirmed after your consultation, and we will let you know if anything needs to change.',
     emptyTitle: 'No programme is on sale right now.',
     emptyBody: 'Please check again shortly.',
     successTitle: 'Your payment is complete.',
@@ -270,7 +281,7 @@ export const TRAINING_COPY: Record<TrainingLang, {
     failContact: 'If you were charged but still see this screen, contact us with your payment number.',
     retry: 'Try again',
     confirmFailTitle: 'We could not confirm your payment.',
-    currencyNotice: 'All payments are charged in Korean won (KRW).',
+    currencyNotice: 'The base currency is Korean won (KRW). Only PayPal is billed in a foreign currency, since PayPal does not support KRW.',
   },
   ja: {
     eyebrow: 'GRIGO PROGRAM',
@@ -304,14 +315,18 @@ export const TRAINING_COPY: Record<TrainingLang, {
     paymentNo: '決済番号',
     payOnce: (amount) => `${amount}をお支払いいただきます。`,
     payInstallment: (amount, months) => `${months}回のうち1回目の${amount}をお支払いいただきます。`,
-    methodDomestic: '韓国内決済 (トスペイメンツ)',
-    methodDomesticDesc: 'カード · 口座振替 · 簡単決済',
-    methodOverseas: '海外決済 (PayPal)',
+    methodCard: 'カード決済',
+    methodCardDesc: '国内外のクレジット・デビットカード（ウォン建て）',
+    methodTransfer: '口座振替',
+    methodTransferDesc: '韓国の銀行からのリアルタイム振替（ウォン建て）',
+    methodOverseas: 'PayPal',
     methodOverseasDesc: '海外カード · PayPal残高',
+    paypalCurrencyNotice: (foreign, krw) =>
+      `PayPalはウォン建て決済に対応していないため${foreign}で請求されます。基準金額は${krw}で、為替変動に備えた余裕分が含まれています。`,
     paySubmit: (amount) => `${amount}を決済する`,
     editInfo: '情報を修正する',
     notice:
-      '韓国内決済はトスペイメンツ、海外決済はPayPalで処理されます。進行経路と必要な範囲は相談後に確定し、変更が必要な場合はご案内します。',
+      'カード決済と口座振替はトスペイメンツ、PayPalはPayPalで処理されます。進行経路と必要な範囲は相談後に確定し、変更が必要な場合はご案内します。',
     emptyTitle: '現在販売中の課程はありません。',
     emptyBody: 'しばらくしてから再度ご確認ください。',
     successTitle: '決済が完了しました。',
@@ -326,6 +341,6 @@ export const TRAINING_COPY: Record<TrainingLang, {
     failContact: '決済されたのにこの画面が表示される場合は、決済番号を添えてお問い合わせください。',
     retry: 'もう一度試す',
     confirmFailTitle: '決済を確認できませんでした。',
-    currencyNotice: 'すべてのお支払いは韓国ウォン(KRW)で請求されます。',
+    currencyNotice: '基本の決済通貨は韓国ウォン(KRW)です。PayPalのみウォンに対応していないため外貨で請求されます。',
   },
 }


### PR DESCRIPTION
## 내용

### 결제수단 3가지
- **카드결제** — 토스페이먼츠 카드 결제창 (원화)
- **계좌이체** — 토스페이먼츠 퀵계좌이체 (원화)
- **PayPal** — 해외 카드·PayPal 잔액

토스는 결제위젯 대신 `payment.requestPayment({ method })` 를 써서 카드/계좌이체를 명시적으로 분리했다.

### 환율
PayPal은 KRW를 지원하지 않으므로(`CURRENCY_NOT_SUPPORTED`) 외화로 청구한다.
환율은 **시장가보다 보수적으로** 잡아 실수취 원화가 정가보다 적어지지 않게 했다.

- `PAYPAL_KRW_PER_USD` 기본 **1350** (2026-07-30 시장 1USD≈1,449원)
- 외화 금액은 **절상(ceil)**
- 예: 400만원 → $2,963 → 시장 환산 약 4,293,000원 (정가 대비 +7%)

환산 정책은 `src/lib/paypal-fx.ts` 한 곳에 모아, 결제 전 견적과 실제 청구가 같은 값을 쓰도록 했다.
결제 전 화면에도 "PayPal은 원화 결제를 지원하지 않아 $X로 청구된다"고 안내한다.

## 검증

- `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)