### PR TITLE
feat(training): 결제 심사용 사업자 정보 푸터

### DIFF
--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -7,6 +7,7 @@ import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
 import { TossCheckout, type TossMethod } from '@/components/payments/TossCheckout'
 import { PayPalCheckout } from '@/components/payments/PayPalCheckout'
+import { MerchantInfoFooter } from '@/components/payments/MerchantInfoFooter'
 import { formatForeign, type ForeignQuote } from '@/lib/paypal-fx'
 import { useLanguage } from '@/contexts/LanguageContext'
 import {
@@ -144,6 +145,7 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
             <h1 className="text-2xl font-bold text-zinc-950">{t.emptyTitle}</h1>
             <p className="mt-3 text-sm text-zinc-600">{t.emptyBody}</p>
           </div>
+          <MerchantInfoFooter lang={lang} />
         </main>
         <Footer />
       </>
@@ -453,6 +455,8 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
             </div>
           </div>
         </section>
+
+        <MerchantInfoFooter lang={lang} />
       </main>
       <Footer />
     </>

--- a/src/app/training/fail/FailClient.tsx
+++ b/src/app/training/fail/FailClient.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation'
 import { XCircle } from 'lucide-react'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
+import { MerchantInfoFooter } from '@/components/payments/MerchantInfoFooter'
 import { useLanguage } from '@/contexts/LanguageContext'
 import { TRAINING_COPY, type TrainingLang } from '@/lib/training-package'
 
@@ -38,6 +39,7 @@ export function FailClient() {
             </Link>
           </div>
         </div>
+        <MerchantInfoFooter lang={lang} />
       </main>
       <Footer />
     </>

--- a/src/app/training/success/SuccessClient.tsx
+++ b/src/app/training/success/SuccessClient.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from 'next/navigation'
 import { CheckCircle2, Loader2, XCircle } from 'lucide-react'
 import { Header } from '@/components/layout/Header'
 import { Footer } from '@/components/layout/Footer'
+import { MerchantInfoFooter } from '@/components/payments/MerchantInfoFooter'
 import { useLanguage } from '@/contexts/LanguageContext'
 import { TRAINING_COPY, formatKrw, type TrainingLang } from '@/lib/training-package'
 
@@ -142,6 +143,7 @@ export function SuccessClient() {
             </div>
           )}
         </div>
+        <MerchantInfoFooter lang={lang} />
       </main>
       <Footer />
     </>

--- a/src/components/payments/MerchantInfoFooter.tsx
+++ b/src/components/payments/MerchantInfoFooter.tsx
@@ -1,0 +1,108 @@
+// 결제(PG) 심사 요건에 따라 결제 상품 페이지에만 노출하는 사업자 정보.
+// 이 컴포넌트는 /training 계열 페이지에서만 사용한다 (사이트 공통 푸터와 별개).
+
+import type { TrainingLang } from '@/lib/training-package'
+
+const MERCHANT = {
+  companyName: '주식회사 그리고엔터테인먼트',
+  ceo: '김현준',
+  businessNumber: '116-81-96848',
+  address: '서울특별시 마포구 성지3길 55, 2층',
+  phone: '02-6229-9229',
+  email: 'contact@grigoent.co.kr',
+  bankAccount: '우리은행 1005-304-267399 (예금주: 주식회사 그리고엔터테인먼트)',
+  hours: '평일 09:00 ~ 18:00 (KST)',
+}
+
+const COPY: Record<TrainingLang, {
+  title: string
+  companyName: string
+  ceo: string
+  businessNumber: string
+  address: string
+  phone: string
+  email: string
+  bankAccount: string
+  hours: string
+  methods: string
+  methodsValue: string
+  notice: string
+}> = {
+  ko: {
+    title: '판매자 정보',
+    companyName: '상호명',
+    ceo: '대표자',
+    businessNumber: '사업자등록번호',
+    address: '사업장 주소',
+    phone: '고객센터',
+    email: '이메일',
+    bankAccount: '입금 계좌',
+    hours: '상담 가능 시간',
+    methods: '결제 수단',
+    methodsValue: '신용·체크카드, 실시간 계좌이체, PayPal',
+    notice:
+      '결제 및 환불 관련 문의는 위 고객센터 또는 이메일로 연락해 주세요. 상담 가능 시간 내에 순차적으로 안내드립니다.',
+  },
+  en: {
+    title: 'Seller information',
+    companyName: 'Company',
+    ceo: 'Representative',
+    businessNumber: 'Business registration no.',
+    address: 'Address',
+    phone: 'Customer service',
+    email: 'Email',
+    bankAccount: 'Bank account',
+    hours: 'Support hours',
+    methods: 'Payment methods',
+    methodsValue: 'Credit and debit cards, real-time bank transfer, PayPal',
+    notice:
+      'For payment or refund enquiries, please contact us by phone or email. We reply during the support hours above.',
+  },
+  ja: {
+    title: '販売者情報',
+    companyName: '商号',
+    ceo: '代表者',
+    businessNumber: '事業者登録番号',
+    address: '所在地',
+    phone: 'カスタマーセンター',
+    email: 'メール',
+    bankAccount: '振込口座',
+    hours: '対応時間',
+    methods: 'お支払い方法',
+    methodsValue: 'クレジット・デビットカード、リアルタイム口座振替、PayPal',
+    notice:
+      'お支払い・返金に関するお問い合わせは、上記のカスタマーセンターまたはメールへご連絡ください。対応時間内に順次ご案内いたします。',
+  },
+}
+
+export function MerchantInfoFooter({ lang = 'ko' }: { lang?: TrainingLang }) {
+  const t = COPY[lang]
+  const rows: [string, string][] = [
+    [t.companyName, MERCHANT.companyName],
+    [t.ceo, MERCHANT.ceo],
+    [t.businessNumber, MERCHANT.businessNumber],
+    [t.address, MERCHANT.address],
+    [t.phone, MERCHANT.phone],
+    [t.email, MERCHANT.email],
+    [t.hours, MERCHANT.hours],
+    [t.bankAccount, MERCHANT.bankAccount],
+    [t.methods, t.methodsValue],
+  ]
+
+  return (
+    <section className="border-t border-zinc-300 bg-white">
+      <div className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+        <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-500">{t.title}</h2>
+        <dl className="mt-4 grid gap-x-10 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
+          {rows.map(([label, value]) => (
+            <div key={label} className="flex gap-3 border-b border-zinc-200 py-2 text-[13px] leading-6">
+              <dt className="w-32 shrink-0 text-zinc-500">{label}</dt>
+              <dd className="min-w-0 flex-1 break-words text-zinc-900">{value}</dd>
+            </div>
+          ))}
+        </dl>
+        <p className="mt-5 max-w-3xl text-xs leading-6 text-zinc-500">{t.notice}</p>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## 내용

PG 심사 요건에 따라 **결제 상품 페이지에만** 사업자 정보를 노출한다. 사이트 공통 푸터와는 별개 컴포넌트다.

노출 항목
- 상호명 주식회사 그리고엔터테인먼트
- 대표자 김현준
- 사업자등록번호 116-81-96848
- 사업장 주소 서울특별시 마포구 성지3길 55, 2층
- 고객센터 02-6229-9229 / 이메일 contact@grigoent.co.kr
- 상담 가능 시간 평일 09:00~18:00 (KST)
- 입금 계좌 우리은행 1005-304-267399
- 결제 수단 신용·체크카드, 실시간 계좌이체, PayPal

적용 화면: `/training`, `/training/success`, `/training/fail`
라벨은 한국어·영어·일본어를 따르고, 법정 정보 값 자체는 그대로 표기한다.

## 검증

- `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)