### PR TITLE
fix(training): 결제 완료·실패 화면 사업자 정보 서버 렌더

### DIFF
--- a/src/app/training/fail/page.tsx
+++ b/src/app/training/fail/page.tsx
@@ -2,6 +2,10 @@ import { Suspense } from 'react'
 import type { Metadata } from 'next'
 import { FailClient } from './FailClient'
 
+// searchParams 를 쓰는 클라이언트 화면이라 정적 프리렌더 시 본문이 비어 나간다.
+// 결제 심사에서 사업자 정보가 초기 HTML에 보이도록 요청 시 렌더로 고정한다.
+export const dynamic = 'force-dynamic'
+
 export const metadata: Metadata = {
   title: '결제 실패 - 그리고 엔터테인먼트',
   robots: { index: false, follow: false },

--- a/src/app/training/success/page.tsx
+++ b/src/app/training/success/page.tsx
@@ -2,6 +2,10 @@ import { Suspense } from 'react'
 import type { Metadata } from 'next'
 import { SuccessClient } from './SuccessClient'
 
+// searchParams 를 쓰는 클라이언트 화면이라 정적 프리렌더 시 본문이 비어 나간다.
+// 결제 심사에서 사업자 정보가 초기 HTML에 보이도록 요청 시 렌더로 고정한다.
+export const dynamic = 'force-dynamic'
+
 export const metadata: Metadata = {
   title: '결제 완료 - 그리고 엔터테인먼트',
   robots: { index: false, follow: false },


### PR DESCRIPTION
결제 완료·실패 화면이 정적 프리렌더돼 **초기 HTML에 사업자 정보가 없었다**. 브라우저에서는 보이지만 심사 도구가 정적으로 확인하면 누락으로 잡힐 수 있어 요청 시 렌더(`force-dynamic`)로 고정했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)