### PR TITLE
content(training): 캐스팅·유급 일감·비자 언급 제거

### DIFF
--- a/src/app/training/page.tsx
+++ b/src/app/training/page.tsx
@@ -6,13 +6,13 @@ import { TRAINING_PRODUCT_SLUG, type TrainingPlan, type TrainingProduct } from '
 export const dynamic = 'force-dynamic'
 
 export const metadata: Metadata = {
-  title: '트레이닝 + 실무투입 패키지 - 그리고 엔터테인먼트',
+  title: '한국 활동 준비 트레이닝 패키지 - 그리고 엔터테인먼트',
   description:
-    '전문 트레이닝과 실무 투입을 결합한 GRIGO 패키지입니다. 일시불과 3·4·5개월 분납 중 선택해 결제할 수 있습니다.',
+    '전문 댄스 트레이닝, 한국어 교육, 한국 댄스 업계 실무 교육으로 구성된 GRIGO 교육 패키지입니다. 일시불과 3·4·5개월 분납 중 선택해 결제할 수 있습니다.',
   alternates: { canonical: '/training' },
   openGraph: {
-    title: '트레이닝 + 실무투입 패키지 - 그리고 엔터테인먼트',
-    description: '전문 트레이닝과 실무 투입을 결합한 GRIGO 패키지 결제 페이지입니다.',
+    title: '한국 활동 준비 트레이닝 패키지 - 그리고 엔터테인먼트',
+    description: '전문 댄스 트레이닝과 한국어·업계 교육으로 구성된 GRIGO 교육 패키지 결제 페이지입니다.',
     url: 'https://grigoent.co.kr/training',
     type: 'website',
   },

--- a/src/components/legal/LegalPage.tsx
+++ b/src/components/legal/LegalPage.tsx
@@ -115,9 +115,9 @@ export function LegalPage({
           </div>
 
           <div className="mt-14 border-t border-zinc-200 pt-6 text-sm leading-7 text-zinc-600">
-            <p className="font-semibold text-zinc-900">주식회사 그리고엔터테인먼트</p>
+            <p className="font-semibold text-zinc-900">(주) 그리고엔터테인먼트</p>
             <p>대표자 김현준 · 사업자등록번호 116-81-96848</p>
-            <p>서울특별시 마포구 성지3길 55, 2층</p>
+            <p>서울특별시 마포구 성지3길 55, 2층 202호 (합정동, 아진)</p>
             <p>고객센터 02-6229-9229 · contact@grigoent.co.kr · 평일 09:00 ~ 18:00 (KST)</p>
           </div>
         </div>

--- a/src/components/payments/MerchantInfoFooter.tsx
+++ b/src/components/payments/MerchantInfoFooter.tsx
@@ -5,10 +5,12 @@ import Link from 'next/link'
 import type { TrainingLang } from '@/lib/training-package'
 
 const MERCHANT = {
-  companyName: '주식회사 그리고엔터테인먼트',
+  // ⚠️ 상호·주소는 사업자등록증 표기와 글자 단위로 일치해야 한다(토스 카드사 심사 요건).
+  // 정본: 2025-09-17 재발급 사업자등록증 — 층수·동호수·법정동까지 그대로.
+  companyName: '(주) 그리고엔터테인먼트',
   ceo: '김현준',
   businessNumber: '116-81-96848',
-  address: '서울특별시 마포구 성지3길 55, 2층',
+  address: '서울특별시 마포구 성지3길 55, 2층 202호 (합정동, 아진)',
   phone: '02-6229-9229',
   email: 'contact@grigoent.co.kr',
   bankAccount: '우리은행 1005-304-267399 (예금주: 주식회사 그리고엔터테인먼트)',
@@ -42,6 +44,8 @@ const COPY: Record<TrainingLang, {
     email: '이메일',
     bankAccount: '입금 계좌',
     hours: '상담 가능 시간',
+    servicePeriod: '서비스 제공 기간',
+    servicePeriodValue: '결제일로부터 최소 3개월 ~ 최대 6개월 (진행 상황에 따라 변동)',
     methods: '결제 수단',
     methodsValue: '신용·체크카드, 실시간 계좌이체, PayPal',
     notice:
@@ -60,6 +64,8 @@ const COPY: Record<TrainingLang, {
     email: 'Email',
     bankAccount: 'Bank account',
     hours: 'Support hours',
+    servicePeriod: 'Service period',
+    servicePeriodValue: 'From 3 months up to 6 months from the payment date',
     methods: 'Payment methods',
     methodsValue: 'Credit and debit cards, real-time bank transfer, PayPal',
     notice:
@@ -78,6 +84,8 @@ const COPY: Record<TrainingLang, {
     email: 'メール',
     bankAccount: '振込口座',
     hours: '対応時間',
+    servicePeriod: 'サービス提供期間',
+    servicePeriodValue: 'お支払い日から最短3ヶ月〜最長6ヶ月',
     methods: 'お支払い方法',
     methodsValue: 'クレジット・デビットカード、リアルタイム口座振替、PayPal',
     notice:
@@ -99,6 +107,7 @@ export function MerchantInfoFooter({ lang = 'ko' }: { lang?: TrainingLang }) {
     [t.email, MERCHANT.email],
     [t.hours, MERCHANT.hours],
     [t.bankAccount, MERCHANT.bankAccount],
+    [t.servicePeriod, t.servicePeriodValue],
     [t.methods, t.methodsValue],
   ]
 

--- a/src/lib/training-package.ts
+++ b/src/lib/training-package.ts
@@ -1,4 +1,5 @@
-// 트레이닝 + 실무투입 패키지 판매 공용 타입/헬퍼.
+// 한국 활동 준비 트레이닝 패키지 판매 공용 타입/헬퍼.
+// slug 은 training-and-placement 로 유지한다(주문·정산 식별자라 변경 시 기존 주문이 끊긴다).
 // 상품·요금제 정본은 grigoent Supabase `training_products` / `training_price_plans` 이며,
 // 금액은 서버가 항상 DB 값으로 재계산한다 (클라이언트 값 신뢰 금지).
 // 결제 통화는 언어와 무관하게 항상 원화(KRW)다.
@@ -170,9 +171,9 @@ export const TRAINING_COPY: Record<TrainingLang, {
     processTitle: '진행 방식',
     process: [
       { title: '상담', body: '현재 상황과 목표를 확인하고 필요한 과정을 함께 정리합니다.' },
-      { title: '트레이닝', body: '전문 트레이닝 과정을 통해 실무에 필요한 기준까지 끌어올립니다.' },
-      { title: '실무 투입', body: '준비가 된 인원부터 실제 현장과 프로젝트에 투입됩니다.' },
-      { title: '활동 관리', body: '계약과 행정 절차, 이후 활동까지 매니지먼트가 함께 관리합니다.' },
+      { title: '댄스 트레이닝', body: '전문 트레이닝 과정을 통해 실무에 필요한 기준까지 끌어올립니다.' },
+      { title: '한국어·업계 교육', body: '한국어와 한국 댄스 업계의 실무 지식을 함께 익힙니다.' },
+      { title: '플랫폼 등록', body: '댄서 활동 플랫폼에 등록해 한국에서의 활동 기반을 마련합니다.' },
     ],
     planTitle: '결제 방식 선택',
     planIntro:
@@ -229,9 +230,9 @@ export const TRAINING_COPY: Record<TrainingLang, {
     processTitle: 'How it works',
     process: [
       { title: 'Consultation', body: 'We review your situation and goals, then map out what you actually need.' },
-      { title: 'Training', body: 'Professional training brings you up to the standard the field requires.' },
-      { title: 'Placement', body: 'Once you are ready, you go into real projects and real sets.' },
-      { title: 'Management', body: 'Contracts, paperwork, and your activity afterwards are managed with you.' },
+      { title: 'Dance training', body: 'Professional training brings you up to the standard the field requires.' },
+      { title: 'Korean and industry', body: 'You learn Korean along with how the Korean dance industry actually works.' },
+      { title: 'Platform registration', body: 'You are registered on a dancer activity platform to build your base in Korea.' },
     ],
     planTitle: 'Choose how you pay',
     planIntro:
@@ -289,9 +290,9 @@ export const TRAINING_COPY: Record<TrainingLang, {
     processTitle: '進行の流れ',
     process: [
       { title: '相談', body: '現在の状況と目標を確認し、必要な過程を一緒に整理します。' },
-      { title: 'トレーニング', body: '専門トレーニングで実務に必要な水準まで引き上げます。' },
-      { title: '実務投入', body: '準備ができた方から実際の現場とプロジェクトに参加します。' },
-      { title: '活動管理', body: '契約や行政手続き、その後の活動までマネジメントが一緒に管理します。' },
+      { title: 'ダンストレーニング', body: '専門トレーニングで実務に必要な水準まで引き上げます。' },
+      { title: '韓国語・業界教育', body: '韓国語と韓国ダンス業界の実務知識を一緒に学びます。' },
+      { title: 'プラットフォーム登録', body: 'ダンサー活動プラットフォームに登録し、韓国での活動基盤を整えます。' },
     ],
     planTitle: 'お支払い方法の選択',
     planIntro:


### PR DESCRIPTION
판매 대상은 교육 패키지이며 캐스팅·유급 일감·비자 발급은 상품 범위가 아니다.
보장할 수 없는 항목을 아예 언급하지 않으면 "보장하지 않는다"는 단서도 불필요해진다.

| 항목 | 이전 | 이후 |
|---|---|---|
| 상품명 | 트레이닝 + 실무투입 패키지 | 한국 활동 준비 트레이닝 패키지 |
| 부제 | …전문 트레이닝과 **실무 투입** 과정 | 한국에서 활동하려는 해외 댄서를 위한 전문 교육 과정 |
| 하이라이트 | 실무 투입 기회 제공 / 계약 및 행정 절차 지원 | 한국어 교육 / 한국 댄스 업계 실무 교육 / 댄서 활동 플랫폼 등록 |
| 진행 3단계 | 실무 투입 — 실제 현장과 프로젝트에 투입 | 한국어·업계 교육 |
| 진행 4단계 | 활동 관리 — 계약과 행정 절차 | 플랫폼 등록 |

ko/en/ja 3개 언어 모두 반영. slug은 주문·정산 식별자라 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)