### PR TITLE
feat(training): 분납 회차별 결제링크

### DIFF
--- a/src/app/api/training/confirm/route.ts
+++ b/src/app/api/training/confirm/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { installmentPayUrl } from '@/lib/training-installment-token'
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://grigoent.co.kr'
 
 function getSupabase() {
   return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
@@ -117,6 +120,21 @@ export async function POST(request: NextRequest) {
       })
       .eq('id', paymentRow.order_id)
 
+    // 남은 회차 결제 링크. 분납은 회차마다 서명 링크로 직접 결제한다(자동결제 부가계약 전 운영 방식).
+    const { data: remainingRows } = await supabase
+      .from('training_order_payments')
+      .select('id, sequence, amount, due_date')
+      .eq('order_id', paymentRow.order_id)
+      .neq('status', 'paid')
+      .order('sequence', { ascending: true })
+
+    const remaining = (remainingRows ?? []).map((row) => ({
+      sequence: row.sequence as number,
+      amount: row.amount as number,
+      dueDate: row.due_date as string | null,
+      payUrl: installmentPayUrl(row.id as string, SITE_URL),
+    }))
+
     return NextResponse.json({
       success: true,
       orderNo: order?.order_no ?? null,
@@ -125,6 +143,7 @@ export async function POST(request: NextRequest) {
       paidAmount,
       totalAmount: order?.total_amount ?? amount,
       receiptUrl: tossData?.receipt?.url ?? null,
+      remaining,
     })
   } catch (error) {
     console.error('[training/confirm] unexpected error:', error)

--- a/src/app/api/training/installment/prepare/route.ts
+++ b/src/app/api/training/installment/prepare/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { verifyInstallmentToken } from '@/lib/training-installment-token'
+
+function getSupabase() {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+}
+
+// 분납 2회차 이후 결제 준비.
+// 링크 토큰으로 회차를 특정하고, 결제 금액은 항상 DB 회차 레코드에서만 읽는다(클라이언트 값 신뢰 금지).
+// pg_order_id 는 이 시점에 발급하며 이미 있으면 재사용해 멱등을 유지한다.
+export async function POST(request: NextRequest) {
+  try {
+    const { token } = (await request.json()) as { token?: string }
+    const paymentId = verifyInstallmentToken(token)
+    if (!paymentId) {
+      return NextResponse.json({ success: false, error: '유효하지 않은 결제 링크입니다.' }, { status: 400 })
+    }
+
+    const supabase = getSupabase()
+    const { data: payment, error } = await supabase
+      .from('training_order_payments')
+      .select('id, order_id, sequence, amount, currency, status, due_date, pg_order_id')
+      .eq('id', paymentId)
+      .maybeSingle()
+
+    if (error || !payment) {
+      return NextResponse.json({ success: false, error: '결제 회차를 찾을 수 없습니다.' }, { status: 404 })
+    }
+    if (payment.status === 'paid') {
+      return NextResponse.json({ success: false, error: 'already_paid' }, { status: 409 })
+    }
+
+    const { data: order } = await supabase
+      .from('training_orders')
+      .select(
+        'id, order_no, customer_name, customer_email, customer_phone, preferred_lang, installment_months, total_amount, paid_amount, billing_customer_key',
+      )
+      .eq('id', payment.order_id)
+      .maybeSingle()
+
+    if (!order) {
+      return NextResponse.json({ success: false, error: '주문을 찾을 수 없습니다.' }, { status: 404 })
+    }
+
+    let pgOrderId = payment.pg_order_id as string | null
+    if (!pgOrderId) {
+      pgOrderId = `${order.order_no}-${payment.sequence}`
+      const { error: updateError } = await supabase
+        .from('training_order_payments')
+        .update({ pg_order_id: pgOrderId, pg_provider: 'toss', updated_at: new Date().toISOString() })
+        .eq('id', payment.id)
+      if (updateError) {
+        console.error('[training/installment/prepare] pg_order_id 발급 실패:', updateError)
+        return NextResponse.json({ success: false, error: '결제 준비에 실패했습니다.' }, { status: 500 })
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      pgOrderId,
+      orderNo: order.order_no,
+      sequence: payment.sequence,
+      installmentMonths: order.installment_months,
+      amount: payment.amount,
+      currency: payment.currency,
+      dueDate: payment.due_date,
+      totalAmount: order.total_amount,
+      paidAmount: order.paid_amount ?? 0,
+      customerName: order.customer_name,
+      customerEmail: order.customer_email,
+      customerPhone: order.customer_phone,
+      customerKey: order.billing_customer_key,
+      preferredLang: order.preferred_lang ?? 'ko',
+    })
+  } catch (err) {
+    console.error('[training/installment/prepare] unexpected error:', err)
+    return NextResponse.json({ success: false, error: '결제 준비 중 오류가 발생했습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/training/pay/[token]/PayClient.tsx
+++ b/src/app/training/pay/[token]/PayClient.tsx
@@ -1,0 +1,289 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Loader2 } from 'lucide-react'
+import { Header } from '@/components/layout/Header'
+import { Footer } from '@/components/layout/Footer'
+import { TossCheckout, type TossMethod } from '@/components/payments/TossCheckout'
+import { MerchantInfoFooter } from '@/components/payments/MerchantInfoFooter'
+import { formatKrw, type TrainingLang } from '@/lib/training-package'
+
+type Prepared = {
+  pgOrderId: string
+  orderNo: string
+  sequence: number
+  installmentMonths: number
+  amount: number
+  dueDate: string | null
+  totalAmount: number
+  paidAmount: number
+  customerName: string
+  customerEmail: string
+  customerPhone: string | null
+  customerKey: string | null
+  preferredLang: string
+}
+
+const COPY: Record<TrainingLang, {
+  eyebrow: string
+  title: string
+  intro: string
+  labelOrderNo: string
+  labelSequence: string
+  labelDue: string
+  labelAmount: string
+  labelProgress: string
+  methodCard: string
+  methodCardDesc: string
+  methodTransfer: string
+  methodTransferDesc: string
+  submit: (amount: string) => string
+  loading: string
+  paidTitle: string
+  paidBody: string
+  invalidTitle: string
+  invalidBody: string
+  home: string
+  notice: string
+}> = {
+  ko: {
+    eyebrow: '분납 결제',
+    title: '남은 회차 결제',
+    intro: '아래 회차의 결제를 진행합니다. 금액은 최초 결제 시 확정된 회차 금액입니다.',
+    labelOrderNo: '결제번호',
+    labelSequence: '회차',
+    labelDue: '예정일',
+    labelAmount: '이번 회차 금액',
+    labelProgress: '누적 결제',
+    methodCard: '카드결제',
+    methodCardDesc: '국내외 신용·체크카드 (원화 결제)',
+    methodTransfer: '계좌이체',
+    methodTransferDesc: '국내 은행 실시간 계좌이체 (원화 결제)',
+    submit: (amount) => `${amount} 결제하기`,
+    loading: '결제 정보를 불러오는 중…',
+    paidTitle: '이미 결제가 완료된 회차입니다.',
+    paidBody: '중복 결제되지 않았습니다. 문의가 필요하면 고객센터로 연락해 주세요.',
+    invalidTitle: '유효하지 않은 결제 링크입니다.',
+    invalidBody: '링크가 만료되었거나 잘못되었습니다. 고객센터로 문의해 주세요.',
+    home: '홈으로',
+    notice: '카드결제와 계좌이체는 토스페이먼츠에서 처리됩니다.',
+  },
+  en: {
+    eyebrow: 'Installment payment',
+    title: 'Pay your next instalment',
+    intro: 'This pays the instalment below. The amount was fixed when you first checked out.',
+    labelOrderNo: 'Payment number',
+    labelSequence: 'Instalment',
+    labelDue: 'Due date',
+    labelAmount: 'Amount due',
+    labelProgress: 'Paid so far',
+    methodCard: 'Card',
+    methodCardDesc: 'Korean and overseas credit/debit cards (charged in KRW)',
+    methodTransfer: 'Bank transfer',
+    methodTransferDesc: 'Real-time transfer from a Korean bank (charged in KRW)',
+    submit: (amount) => `Pay ${amount}`,
+    loading: 'Loading your payment details…',
+    paidTitle: 'This instalment is already paid.',
+    paidBody: 'You have not been charged twice. Contact us if anything looks wrong.',
+    invalidTitle: 'This payment link is not valid.',
+    invalidBody: 'The link may have expired or been altered. Please contact us.',
+    home: 'Home',
+    notice: 'Card and bank transfer payments are processed by Toss Payments.',
+  },
+  ja: {
+    eyebrow: '分割払い',
+    title: '次回分のお支払い',
+    intro: '下記の回次のお支払いを行います。金額は初回決済時に確定した金額です。',
+    labelOrderNo: '決済番号',
+    labelSequence: '回次',
+    labelDue: '予定日',
+    labelAmount: '今回のお支払い金額',
+    labelProgress: 'お支払い累計',
+    methodCard: 'カード決済',
+    methodCardDesc: '国内外のクレジット・デビットカード（ウォン建て）',
+    methodTransfer: '口座振替',
+    methodTransferDesc: '韓国の銀行のリアルタイム口座振替（ウォン建て）',
+    submit: (amount) => `${amount}を支払う`,
+    loading: '決済情報を読み込んでいます…',
+    paidTitle: 'この回次はすでにお支払い済みです。',
+    paidBody: '二重に請求されてはいません。ご不明な点はカスタマーセンターまでご連絡ください。',
+    invalidTitle: '有効な決済リンクではありません。',
+    invalidBody: 'リンクの有効期限が切れているか、正しくありません。お問い合わせください。',
+    home: 'ホームへ',
+    notice: 'カード決済と口座振替はトスペイメンツが処理します。',
+  },
+}
+
+function normalizeLang(value: string | undefined): TrainingLang {
+  return value === 'en' || value === 'ja' ? value : 'ko'
+}
+
+export function PayClient({ token }: { token: string }) {
+  const [state, setState] = useState<'loading' | 'ready' | 'paid' | 'invalid'>('loading')
+  const [data, setData] = useState<Prepared | null>(null)
+  const [method, setMethod] = useState<TossMethod>('CARD')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    fetch('/api/training/installment/prepare', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    })
+      .then(async (res) => ({ ok: res.ok, status: res.status, body: await res.json() }))
+      .then(({ ok, status, body }) => {
+        if (!alive) return
+        if (ok && body.success) {
+          setData(body as Prepared)
+          setState('ready')
+        } else if (status === 409) {
+          setState('paid')
+        } else {
+          setState('invalid')
+        }
+      })
+      .catch(() => {
+        if (alive) setState('invalid')
+      })
+    return () => {
+      alive = false
+    }
+  }, [token])
+
+  const lang = normalizeLang(data?.preferredLang)
+  const t = COPY[lang]
+
+  const origin = typeof window !== 'undefined' ? window.location.origin : 'https://grigoent.co.kr'
+  const successUrl = data
+    ? `${origin}/training/success?orderNo=${encodeURIComponent(data.orderNo)}&sequence=${data.sequence}&installmentMonths=${data.installmentMonths}&lang=${lang}`
+    : ''
+  const failUrl = `${origin}/training/fail?lang=${lang}`
+
+  return (
+    <>
+      <Header />
+      <main className="bg-white pt-16 [word-break:keep-all]">
+        <section className="border-b border-zinc-800 bg-zinc-950 text-white">
+          <div className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-400">{t.eyebrow}</p>
+            <h1 className="mt-3 text-2xl font-black tracking-tight sm:text-3xl">{t.title}</h1>
+          </div>
+        </section>
+
+        <div className="mx-auto max-w-3xl px-4 py-10 sm:px-6 lg:px-8">
+          {state === 'loading' ? (
+            <p className="flex items-center gap-2 text-sm text-zinc-600">
+              <Loader2 className="size-4 animate-spin" />
+              {t.loading}
+            </p>
+          ) : null}
+
+          {state === 'invalid' || state === 'paid' ? (
+            <div className="border border-zinc-300 p-6">
+              <p className="text-lg font-bold text-zinc-950">
+                {state === 'paid' ? t.paidTitle : t.invalidTitle}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-zinc-600">
+                {state === 'paid' ? t.paidBody : t.invalidBody}
+              </p>
+              <Link href="/" className="mt-5 inline-block border border-zinc-950 px-4 py-2 text-sm font-semibold">
+                {t.home}
+              </Link>
+            </div>
+          ) : null}
+
+          {state === 'ready' && data ? (
+            <>
+              <p className="text-sm leading-6 text-zinc-600">{t.intro}</p>
+
+              <dl className="mt-6 grid gap-x-8 gap-y-3 border-y border-zinc-200 py-5 sm:grid-cols-2">
+                <div className="flex justify-between gap-4 text-sm">
+                  <dt className="text-zinc-500">{t.labelOrderNo}</dt>
+                  <dd className="font-mono font-semibold text-zinc-950">{data.orderNo}</dd>
+                </div>
+                <div className="flex justify-between gap-4 text-sm">
+                  <dt className="text-zinc-500">{t.labelSequence}</dt>
+                  <dd className="font-semibold text-zinc-950">
+                    {data.sequence} / {data.installmentMonths}
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4 text-sm">
+                  <dt className="text-zinc-500">{t.labelDue}</dt>
+                  <dd className="text-zinc-950">{data.dueDate ?? '-'}</dd>
+                </div>
+                <div className="flex justify-between gap-4 text-sm">
+                  <dt className="text-zinc-500">{t.labelProgress}</dt>
+                  <dd className="text-zinc-950">
+                    {formatKrw(data.paidAmount, lang)} / {formatKrw(data.totalAmount, lang)}
+                  </dd>
+                </div>
+              </dl>
+
+              <p className="mt-6 text-xs font-semibold uppercase tracking-[0.16em] text-zinc-500">
+                {t.labelAmount}
+              </p>
+              <p className="mt-1 text-3xl font-black tracking-tight text-zinc-950">
+                {formatKrw(data.amount, lang)}
+              </p>
+
+              <div className="mt-6 grid gap-2 sm:grid-cols-2">
+                {(
+                  [
+                    { key: 'CARD' as const, label: t.methodCard, desc: t.methodCardDesc },
+                    { key: 'TRANSFER' as const, label: t.methodTransfer, desc: t.methodTransferDesc },
+                  ]
+                ).map((m) => (
+                  <button
+                    key={m.key}
+                    type="button"
+                    onClick={() => setMethod(m.key)}
+                    className={
+                      method === m.key
+                        ? 'border border-zinc-950 bg-zinc-950 p-4 text-left text-white'
+                        : 'border border-zinc-300 p-4 text-left transition hover:border-zinc-950'
+                    }
+                  >
+                    <span className="block text-sm font-semibold">{m.label}</span>
+                    <span
+                      className={
+                        method === m.key ? 'mt-1 block text-xs text-zinc-300' : 'mt-1 block text-xs text-zinc-500'
+                      }
+                    >
+                      {m.desc}
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="mt-4">
+                <TossCheckout
+                  method={method}
+                  amount={data.amount}
+                  orderId={data.pgOrderId}
+                  orderName={`${data.orderNo} ${data.sequence}/${data.installmentMonths}`}
+                  customerName={data.customerName}
+                  customerEmail={data.customerEmail}
+                  customerMobilePhone={data.customerPhone ?? undefined}
+                  customerKey={data.customerKey ?? undefined}
+                  successUrl={successUrl}
+                  failUrl={failUrl}
+                  submitLabel={t.submit(formatKrw(data.amount, lang))}
+                  lang={lang}
+                  onError={setError}
+                />
+              </div>
+
+              {error ? <p className="mt-3 text-sm text-red-600">{error}</p> : null}
+              <p className="mt-4 text-xs leading-6 text-zinc-500">{t.notice}</p>
+            </>
+          ) : null}
+        </div>
+
+        <MerchantInfoFooter lang={lang} />
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/training/pay/[token]/page.tsx
+++ b/src/app/training/pay/[token]/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next'
+import { PayClient } from './PayClient'
+
+// 회차 정보를 서버에서 읽어 렌더하므로 정적 프리렌더를 막는다.
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: '분납 회차 결제 - 그리고 엔터테인먼트',
+  robots: { index: false, follow: false },
+}
+
+export default async function TrainingInstallmentPayPage({
+  params,
+}: {
+  params: Promise<{ token: string }>
+}) {
+  const { token } = await params
+  return <PayClient token={token} />
+}

--- a/src/app/training/success/SuccessClient.tsx
+++ b/src/app/training/success/SuccessClient.tsx
@@ -18,7 +18,30 @@ type Result = {
   paidAmount?: number
   totalAmount?: number
   receiptUrl?: string | null
+  remaining?: { sequence: number; amount: number; dueDate: string | null; payUrl: string }[]
   error?: string
+}
+
+// 남은 회차 안내 문구 (분납 전용).
+const REMAINING_COPY: Record<TrainingLang, { title: string; intro: string; due: string; pay: string }> = {
+  ko: {
+    title: '남은 회차',
+    intro: '아래 링크에서 회차별로 결제하실 수 있습니다. 예정일에 맞춰 안내도 드립니다.',
+    due: '예정일',
+    pay: '결제하기',
+  },
+  en: {
+    title: 'Remaining instalments',
+    intro: 'You can pay each instalment from the links below. We will also remind you near each due date.',
+    due: 'Due',
+    pay: 'Pay',
+  },
+  ja: {
+    title: '残りの回次',
+    intro: '下記のリンクから回次ごとにお支払いいただけます。予定日に合わせてご案内もいたします。',
+    due: '予定日',
+    pay: 'お支払い',
+  },
 }
 
 export function SuccessClient() {
@@ -109,6 +132,33 @@ export function SuccessClient() {
                   </dd>
                 </div>
               </dl>
+              {result.remaining && result.remaining.length > 0 ? (
+                <div className="mt-8 border-t border-zinc-300 pt-6">
+                  <p className="text-sm font-bold text-zinc-950">{REMAINING_COPY[lang].title}</p>
+                  <p className="mt-1 text-xs leading-6 text-zinc-500">{REMAINING_COPY[lang].intro}</p>
+                  <ul className="mt-4 grid gap-2">
+                    {result.remaining.map((row) => (
+                      <li
+                        key={row.sequence}
+                        className="flex flex-wrap items-center justify-between gap-3 border border-zinc-200 px-4 py-3 text-sm"
+                      >
+                        <span className="font-semibold text-zinc-950">
+                          {row.sequence} / {result.installmentMonths} · {formatKrw(row.amount, lang)}
+                        </span>
+                        <span className="text-xs text-zinc-500">
+                          {REMAINING_COPY[lang].due} {row.dueDate ?? '-'}
+                        </span>
+                        <a
+                          href={row.payUrl}
+                          className="inline-flex min-h-9 items-center border border-zinc-950 px-3 text-xs font-semibold text-zinc-950 transition hover:bg-zinc-950 hover:text-white"
+                        >
+                          {REMAINING_COPY[lang].pay}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
               <div className="mt-8 flex flex-wrap gap-3">
                 {result.receiptUrl ? (
                   <a

--- a/src/lib/training-installment-token.ts
+++ b/src/lib/training-installment-token.ts
@@ -1,0 +1,45 @@
+import { createHmac, timingSafeEqual } from 'crypto'
+
+// 분납 회차별 결제 링크 토큰.
+// 회차 레코드 id 를 서버 키로 서명해 링크 하나가 한 회차만 결제하도록 묶는다.
+// (주문번호를 그대로 노출하면 다른 회차·다른 주문을 유추할 수 있어 서명 토큰을 쓴다.)
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function secret(): string {
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!key) throw new Error('SUPABASE_SERVICE_ROLE_KEY is missing')
+  return key
+}
+
+function sign(payload: string, key: string): string {
+  return createHmac('sha256', key).update(payload).digest('base64url')
+}
+
+export function makeInstallmentToken(paymentId: string): string {
+  const payload = `tip:${paymentId}`
+  return `${Buffer.from(payload, 'utf8').toString('base64url')}.${sign(payload, secret())}`
+}
+
+export function verifyInstallmentToken(token: string | null | undefined): string | null {
+  try {
+    if (!token) return null
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+    if (!key) return null
+    const dot = token.lastIndexOf('.')
+    if (dot < 1) return null
+    const payload = Buffer.from(token.slice(0, dot), 'base64url').toString('utf8')
+    const a = Buffer.from(token.slice(dot + 1))
+    const b = Buffer.from(sign(payload, key))
+    if (a.length !== b.length || !timingSafeEqual(a, b)) return null
+    const [prefix, paymentId] = payload.split(':')
+    if (prefix !== 'tip' || !UUID_RE.test(paymentId ?? '')) return null
+    return paymentId
+  } catch {
+    return null
+  }
+}
+
+export function installmentPayUrl(paymentId: string, siteUrl: string): string {
+  return `${siteUrl.replace(/\/$/, '')}/training/pay/${makeInstallmentToken(paymentId)}`
+}


### PR DESCRIPTION
분납 주문은 회차가 `pending` 으로 적재만 되고 **2회차 이후 청구 수단이 없었다**. 1회차만 받고 나머지는 회수 불가 상태.

## 구현
- `/training/pay/{token}` — 회차 id 를 서버 키로 HMAC 서명한 링크
- `/api/training/installment/prepare` — 토큰 검증 → `pg_order_id` 발급(멱등) → 회차 정보 반환
- 금액은 **항상 DB 회차 레코드에서만** 읽는다 (클라이언트 값 신뢰 안 함)
- 결제창은 기존 `TossCheckout`(카드/계좌이체) 재사용, 승인은 기존 `confirm` 이 이미 회차 단위라 그대로 동작
- 결제 완료 화면에 남은 회차 + 각 회차 결제 링크 노출 (ko/en/ja)
- 이미 결제된 회차는 409 로 차단

## 배경
자동결제(빌링)는 토스 부가계약이 필요해 별도 신청 중이며, 승인 전까지의 운영 방식이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)