### PR TITLE
feat(toss): 라이브 키 연동 + 테스트/라이브 전환 스위치

### DIFF
--- a/src/app/api/training/confirm/route.ts
+++ b/src/app/api/training/confirm/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { tossSecretKey } from '@/lib/toss-keys'
 
 function getSupabase() {
   return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
@@ -47,7 +48,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: '결제 금액이 일치하지 않습니다.' }, { status: 400 })
     }
 
-    const secretKey = process.env.TOSS_SECRET_KEY
+    const secretKey = tossSecretKey()
     if (!secretKey) {
       return NextResponse.json({ success: false, error: '결제 설정이 완료되지 않았습니다.' }, { status: 500 })
     }

--- a/src/components/payments/TossCheckout.tsx
+++ b/src/components/payments/TossCheckout.tsx
@@ -4,8 +4,9 @@ import { useCallback, useState } from 'react'
 import { ANONYMOUS, loadTossPayments } from '@tosspayments/tosspayments-sdk'
 import { Loader2 } from 'lucide-react'
 import type { TrainingLang } from '@/lib/training-package'
+import { tossClientKey } from '@/lib/toss-keys'
 
-const clientKey = process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY
+const clientKey = tossClientKey()
 
 export type TossMethod = 'CARD' | 'TRANSFER'
 

--- a/src/lib/toss-keys.ts
+++ b/src/lib/toss-keys.ts
@@ -1,0 +1,27 @@
+// 토스페이먼츠 키 선택 — 테스트/라이브 전환 스위치.
+//
+// 라이브 키는 미리 넣어두되, 카드사 심사가 끝나기 전에는 실결제가 열리지 않아야 한다.
+// (승인된 카드사가 없는 상태로 라이브를 켜면 결제창에서 그대로 실패한다.)
+// 전환은 NEXT_PUBLIC_TOSS_USE_LIVE 를 'true' 로 바꾸고 재배포하면 끝난다.
+//
+// ⚠️ 키 종류 주의: 우리 결제는 payment.requestPayment() 방식이라
+//    "API 개별 연동 키"(live_ck_ / live_sk_)만 동작한다.
+//    "주문서형·결제창형 연동 키"(live_gck_ / live_gsk_)를 넣으면
+//    "API 개별 연동 키의 클라이언트 키로 SDK를 연동해주세요" 오류가 난다.
+//    API 개별 연동 키는 상점아이디(MID)별로 다르며 우리 MID 는 gtrain4o8d 다.
+
+export const TOSS_USE_LIVE = process.env.NEXT_PUBLIC_TOSS_USE_LIVE === 'true'
+
+// 브라우저에서 읽어야 하므로 두 값 모두 NEXT_PUBLIC_ 이어야 한다.
+export function tossClientKey(): string | undefined {
+  return TOSS_USE_LIVE
+    ? process.env.NEXT_PUBLIC_TOSS_LIVE_CLIENT_KEY || process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY
+    : process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY
+}
+
+// 서버 전용. 승인 전에는 테스트 시크릿을 그대로 쓴다.
+export function tossSecretKey(): string | undefined {
+  return TOSS_USE_LIVE
+    ? process.env.TOSS_LIVE_SECRET_KEY || process.env.TOSS_SECRET_KEY
+    : process.env.TOSS_SECRET_KEY
+}


### PR DESCRIPTION
카드사 심사 진행 중이라 승인된 카드사가 없다. 이 상태로 라이브를 켜면 결제가 실패하므로 **키만 미리 넣고 스위치는 꺼둔다.**

- `src/lib/toss-keys.ts` — `NEXT_PUBLIC_TOSS_USE_LIVE` 로 클라이언트/시크릿 키 선택
- 라이브 키는 Vercel env 저장 (`NEXT_PUBLIC_TOSS_LIVE_CLIENT_KEY` / `TOSS_LIVE_SECRET_KEY`)
- **스위치 off 시 기존 테스트 키 그대로** → 동작·화면 변화 없음 (카드사 심사 중 안전)
- 승인 후 `NEXT_PUBLIC_TOSS_USE_LIVE=true` + 재배포로 전환 완료

⚠️ 우리 결제는 `requestPayment` 방식이라 **API 개별 연동 키(ck/sk)**만 동작한다. 결제위젯 키(gck/gsk)는 SDK 연동 오류. MID = `gtrain4o8d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)