### PR TITLE
feat(payment): 오디션 참석 확정비 결제 페이지(/audition-fee)

### DIFF
--- a/src/app/api/training/checkout/route.ts
+++ b/src/app/api/training/checkout/route.ts
@@ -15,6 +15,9 @@ function getSupabase() {
 
 type Body = {
   planCode?: string
+  // 어떤 상품을 결제할지. 생략하면 기존 트레이닝 패키지(하위호환).
+  // 허용 목록에 있는 slug 만 받는다 — 임의 slug 로 비활성 상품을 팔 수 없게.
+  productSlug?: string
   name?: string
   email?: string
   phone?: string
@@ -23,6 +26,8 @@ type Body = {
   memo?: string
   agreed?: boolean
 }
+
+const ALLOWED_PRODUCT_SLUGS = new Set([TRAINING_PRODUCT_SLUG, 'audition-fee'])
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -49,12 +54,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: '결제 진행에 동의해 주세요.' }, { status: 400 })
     }
 
+    const requestedSlug = (body.productSlug ?? '').trim() || TRAINING_PRODUCT_SLUG
+    if (!ALLOWED_PRODUCT_SLUGS.has(requestedSlug)) {
+      return NextResponse.json({ success: false, error: '판매 중인 상품을 찾을 수 없습니다.' }, { status: 404 })
+    }
+
     const supabase = getSupabase()
 
     const { data: product, error: productError } = await supabase
       .from('training_products')
       .select('id, title, currency, is_active')
-      .eq('slug', TRAINING_PRODUCT_SLUG)
+      .eq('slug', requestedSlug)
       .maybeSingle()
 
     if (productError || !product || !product.is_active) {

--- a/src/app/audition-fee/page.tsx
+++ b/src/app/audition-fee/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from 'next'
+import { createClient } from '@supabase/supabase-js'
+import { TrainingClient } from '@/app/training/TrainingClient'
+import type { TrainingPlan, TrainingProduct } from '@/lib/training-package'
+
+// 오디션 참석 확정비 결제 페이지.
+// 토스 카드사 심사 대상 URL(/training)과 분리된 별도 경로이며,
+// 심사 중 그 화면·구성에 영향을 주지 않도록 검색엔진에서도 제외한다.
+export const dynamic = 'force-dynamic'
+
+const PRODUCT_SLUG = 'audition-fee'
+
+export const metadata: Metadata = {
+  title: '오디션 참석 확정비 - 그리고 엔터테인먼트',
+  description: '레벨테스트 오디션 참석을 확정하기 위한 참가비 결제 페이지입니다.',
+  robots: { index: false, follow: false },
+}
+
+export default async function AuditionFeePage() {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  )
+
+  const { data: productRow } = await supabase
+    .from('training_products')
+    .select('id, slug, title, subtitle, description, highlights, currency, i18n')
+    .eq('slug', PRODUCT_SLUG)
+    .eq('is_active', true)
+    .maybeSingle()
+
+  let plans: TrainingPlan[] = []
+  if (productRow) {
+    const { data: planRows } = await supabase
+      .from('training_price_plans')
+      .select('id, code, label, plan_type, installment_months, amount_per_charge, total_amount, currency, note, sort_order, i18n')
+      .eq('product_id', productRow.id)
+      .eq('is_active', true)
+      .order('sort_order', { ascending: true })
+    plans = (planRows ?? []) as unknown as TrainingPlan[]
+  }
+
+  const product = productRow
+    ? ({
+        ...productRow,
+        highlights: Array.isArray(productRow.highlights) ? (productRow.highlights as string[]) : [],
+      } as TrainingProduct)
+    : null
+
+  return <TrainingClient product={product} plans={plans} productSlug={PRODUCT_SLUG} />
+}

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -66,7 +66,16 @@ const inputClass =
 
 const LANG_LABEL: Record<TrainingLang, string> = { ko: '한국어', en: 'EN', ja: '日本語' }
 
-export function TrainingClient({ product, plans }: { product: TrainingProduct | null; plans: TrainingPlan[] }) {
+export function TrainingClient({
+  product,
+  plans,
+  productSlug,
+}: {
+  product: TrainingProduct | null
+  plans: TrainingPlan[]
+  // 생략하면 서버가 기존 트레이닝 패키지로 처리한다(기존 /training 동작 그대로).
+  productSlug?: string
+}) {
   const router = useRouter()
   // 사이트 전역 언어 상태를 그대로 쓴다 (헤더 언어 선택과 연동).
   const { language, setLanguage } = useLanguage()
@@ -101,7 +110,7 @@ export function TrainingClient({ product, plans }: { product: TrainingProduct | 
       const response = await fetch('/api/training/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ planCode, name, email, phone, nationality, memo, agreed, preferredLang: lang }),
+        body: JSON.stringify({ planCode, productSlug, name, email, phone, nationality, memo, agreed, preferredLang: lang }),
       })
       const data = await response.json()
       if (!response.ok || !data.success) {


### PR DESCRIPTION
토스 카드사 심사 중이라 심사 대상 URL(`/training`)은 건드리지 않고 **별도 경로**로 분리했다.

- 상품 `audition-fee` — **100,000원 단건** (DB)
- `/audition-fee` — 기존 `TrainingClient` 재사용, `robots: noindex`
- `checkout` API 에 `productSlug` **옵션** 추가 → 생략 시 기존 동작, `/training` 은 요청·렌더 모두 종전과 동일
- 허용 slug 화이트리스트로 임의 상품 결제 차단

PayPal 라이브(법인 계정)라 실결제 검증 가능. 카드·계좌이체는 심사 완료 전까지 테스트 키.

🤖 Generated with [Claude Code](https://claude.com/claude-code)