### PR TITLE
fix(payments): PayPal SDK 통화 일치 + 안내 문구 정리

### DIFF
--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -424,6 +424,7 @@ export function TrainingClient({
                       <PayPalCheckout
                         pgOrderId={session.pgOrderId}
                         orderName={session.orderName}
+                        currency={session.paypalQuote?.currency}
                         lang={lang}
                         onSuccess={(paid) => {
                           const query = new URLSearchParams({

--- a/src/components/payments/PayPalCheckout.tsx
+++ b/src/components/payments/PayPalCheckout.tsx
@@ -53,6 +53,12 @@ export type PayPalCheckoutProps = {
   /** 우리 시스템의 회차 결제 식별자 (training_order_payments.pg_order_id) */
   pgOrderId: string
   orderName: string
+  /**
+   * SDK 로드 통화. 서버가 만드는 PayPal 주문 통화(foreignQuote)와 반드시 같아야 한다.
+   * 다르면 버튼이 "Expected currency from order api call to be X, got Y" 로 거부한다.
+   * PayPal 은 KRW 를 지원하지 않으므로 기본값은 USD.
+   */
+  currency?: string
   lang?: TrainingLang
   onSuccess: (result: { orderNo: string | null; sequence?: number; paidAmount?: number; totalAmount?: number }) => void
   onError?: (message: string) => void
@@ -151,8 +157,9 @@ export function PayPalCheckout(props: PayPalCheckoutProps) {
       </div>
     )
   }
+  const currency = (props.currency || 'USD').toUpperCase()
   return (
-    <PayPalScriptProvider options={{ clientId, currency: 'KRW', intent: 'capture' }}>
+    <PayPalScriptProvider options={{ clientId, currency, intent: 'capture' }}>
       <Inner {...props} />
     </PayPalScriptProvider>
   )

--- a/src/lib/training-package.ts
+++ b/src/lib/training-package.ts
@@ -203,7 +203,7 @@ export const TRAINING_COPY: Record<TrainingLang, {
     methodOverseas: 'PayPal',
     methodOverseasDesc: '해외 카드 · PayPal 잔액',
     paypalCurrencyNotice: (foreign, krw) =>
-      `PayPal은 원화 결제를 지원하지 않아 ${foreign}로 청구됩니다. 기준 금액은 ${krw}이며, 환율 변동에 대비한 여유분이 포함되어 있습니다.`,
+      `PayPal은 원화 결제를 지원하지 않습니다. 결제 금액 ${krw}은 ${foreign}로 청구됩니다.`,
     paySubmit: (amount) => `${amount} 결제하기`,
     editInfo: '정보 수정하기',
     notice:
@@ -263,7 +263,7 @@ export const TRAINING_COPY: Record<TrainingLang, {
     methodOverseas: 'PayPal',
     methodOverseasDesc: 'International cards · PayPal balance',
     paypalCurrencyNotice: (foreign, krw) =>
-      `PayPal cannot charge Korean won, so you will be billed ${foreign}. The base price is ${krw}, and the amount includes a buffer for exchange rate movement.`,
+      `PayPal cannot charge Korean won. Your payment of ${krw} will be billed as ${foreign}.`,
     paySubmit: (amount) => `Pay ${amount}`,
     editInfo: 'Edit my details',
     notice:
@@ -323,7 +323,7 @@ export const TRAINING_COPY: Record<TrainingLang, {
     methodOverseas: 'PayPal',
     methodOverseasDesc: '海外カード · PayPal残高',
     paypalCurrencyNotice: (foreign, krw) =>
-      `PayPalはウォン建て決済に対応していないため${foreign}で請求されます。基準金額は${krw}で、為替変動に備えた余裕分が含まれています。`,
+      `PayPalはウォン建て決済に対応していません。お支払い金額${krw}は${foreign}で請求されます。`,
     paySubmit: (amount) => `${amount}を決済する`,
     editInfo: '情報を修正する',
     notice:


### PR DESCRIPTION
## 1. PayPal 버튼 통화 불일치 (결제 차단)

콘솔 오류:
```
Expected currency from order api call to be KRW, got USD.
```

`PayPalScriptProvider` 를 `currency: 'KRW'` 로 로드하는데, 서버(`/api/training/paypal/create-order`)는 `foreignQuote()` 기준 **USD** 주문을 만들고 있었습니다.
PayPal 은 KRW 자체를 지원하지 않으므로 USD 가 맞고, SDK 쪽이 틀렸습니다.

`PayPalCheckout` 에 `currency` prop 을 추가해 서버 견적의 통화를 그대로 넘깁니다(기본값 USD).

## 2. 안내 문구

기존: "…기준 금액은 100,000원이며, **환율 변동에 대비한 여유분이 포함되어 있습니다.**"

판매자 내부 사정을 구매자에게 설명하는 문장이라 삭제했습니다.
ko / en / ja 3개 언어 모두 적용.

변경 후: "PayPal은 원화 결제를 지원하지 않습니다. 결제 금액 100,000원은 $75로 청구됩니다."

🤖 Generated with [Claude Code](https://claude.com/claude-code)