### PR TITLE
feat(training): 결제를 deetz 비자 케이스에 연결

### DIFF
--- a/src/app/api/training/checkout/route.ts
+++ b/src/app/api/training/checkout/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { randomBytes, randomUUID } from 'node:crypto'
 import { createClient } from '@supabase/supabase-js'
 import { foreignQuote } from '@/lib/paypal-fx'
+import { verifyVisaPaymentRef } from '@/lib/visa-payment-ref'
 import {
   TRAINING_PRODUCT_SLUG,
   buildDueDates,
@@ -18,6 +19,8 @@ type Body = {
   // 어떤 상품을 결제할지. 생략하면 기존 트레이닝 패키지(하위호환).
   // 허용 목록에 있는 slug 만 받는다 — 임의 slug 로 비활성 상품을 팔 수 없게.
   productSlug?: string
+  // deetz 비자 케이스에서 발급한 결제 링크 토큰. 있으면 주문을 그 케이스에 연결한다.
+  ref?: string
   name?: string
   email?: string
   phone?: string
@@ -59,6 +62,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: '판매 중인 상품을 찾을 수 없습니다.' }, { status: 404 })
     }
 
+    // 토큰이 있어도 결제는 막지 않는다. 검증에 실패하면 케이스 연결만 포기한다.
+    // (링크 만료 때문에 결제를 못 하게 만들면 매출을 잃는다 — 연결은 나중에 수기로도 붙일 수 있다.)
+    const ref = verifyVisaPaymentRef(body.ref)
+    const visaApplicationId = ref && ref.productSlug === requestedSlug ? ref.applicationId : null
+
     const supabase = getSupabase()
 
     const { data: product, error: productError } = await supabase
@@ -99,6 +107,7 @@ export async function POST(request: NextRequest) {
         customer_phone: phone || null,
         customer_nationality: nationality || null,
         preferred_lang: preferredLang,
+        visa_application_id: visaApplicationId,
         pg_provider: 'toss',
         currency: plan.currency,
         total_amount: plan.total_amount,

--- a/src/app/api/training/confirm/route.ts
+++ b/src/app/api/training/confirm/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { tossSecretKey } from '@/lib/toss-keys'
+import { notifyVisaCasePayment } from '@/lib/visa-payment-ref'
 
 function getSupabase() {
   return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
@@ -96,7 +97,9 @@ export async function POST(request: NextRequest) {
 
     const { data: order } = await supabase
       .from('training_orders')
-      .select('id, order_no, total_amount, installment_months, customer_name, customer_email')
+      .select(
+        'id, order_no, total_amount, installment_months, customer_name, customer_email, visa_application_id',
+      )
       .eq('id', paymentRow.order_id)
       .maybeSingle()
 
@@ -117,6 +120,20 @@ export async function POST(request: NextRequest) {
         updated_at: paidAt,
       })
       .eq('id', paymentRow.order_id)
+
+    // deetz 케이스에서 발급한 링크로 결제한 건이면 그쪽 케이스에도 결제 완료를 반영한다.
+    // 실패해도 결제는 이미 승인됐으므로 응답을 막지 않는다.
+    if (order?.visa_application_id && order.order_no) {
+      await notifyVisaCasePayment({
+        applicationId: order.visa_application_id as string,
+        event: 'paid',
+        orderNo: order.order_no,
+        provider: 'toss',
+        amountKrw: paidAmount,
+        occurredAt: paidAt,
+        meta: { paymentKey, sequence: paymentRow.sequence, receiptUrl: tossData?.receipt?.url ?? null },
+      })
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/training/paypal/capture-order/route.ts
+++ b/src/app/api/training/paypal/capture-order/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
+import { notifyVisaCasePayment } from '@/lib/visa-payment-ref'
 
 const PAYPAL_CLIENT_ID = process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID
 const PAYPAL_CLIENT_SECRET = process.env.PAYPAL_CLIENT_SECRET
@@ -98,7 +99,7 @@ export async function POST(request: NextRequest) {
 
     const { data: order } = await supabase
       .from('training_orders')
-      .select('id, order_no, total_amount, installment_months')
+      .select('id, order_no, total_amount, installment_months, visa_application_id')
       .eq('id', paymentRow.order_id)
       .maybeSingle()
 
@@ -120,6 +121,20 @@ export async function POST(request: NextRequest) {
         updated_at: paidAt,
       })
       .eq('id', paymentRow.order_id)
+
+    // deetz 케이스에서 발급한 링크로 결제한 건이면 그쪽 케이스에도 결제 완료를 반영한다.
+    // 실패해도 결제는 이미 승인됐으므로 응답을 막지 않는다.
+    if (order?.visa_application_id && order.order_no) {
+      await notifyVisaCasePayment({
+        applicationId: order.visa_application_id as string,
+        event: 'paid',
+        orderNo: order.order_no,
+        provider: 'paypal',
+        amountKrw: paidAmount,
+        occurredAt: paidAt,
+        meta: { paypalTransactionId: captureDetails?.id ?? null, sequence: paymentRow.sequence },
+      })
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/audition-fee/page.tsx
+++ b/src/app/audition-fee/page.tsx
@@ -16,7 +16,13 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 }
 
-export default async function AuditionFeePage() {
+export default async function AuditionFeePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string }>
+}) {
+  // deetz 케이스에서 발급한 결제 링크 토큰. 검증은 서버(checkout)에서만 한다.
+  const { ref } = await searchParams
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -47,5 +53,5 @@ export default async function AuditionFeePage() {
       } as TrainingProduct)
     : null
 
-  return <TrainingClient product={product} plans={plans} productSlug={PRODUCT_SLUG} />
+  return <TrainingClient product={product} plans={plans} productSlug={PRODUCT_SLUG} paymentRef={ref} />
 }

--- a/src/app/audition-fee/page.tsx
+++ b/src/app/audition-fee/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { createClient } from '@supabase/supabase-js'
 import { TrainingClient } from '@/app/training/TrainingClient'
+import { AUDITION_FEE_COPY } from '@/lib/training-package'
 import type { TrainingPlan, TrainingProduct } from '@/lib/training-package'
 
 // 오디션 참석 확정비 결제 페이지.
@@ -53,5 +54,13 @@ export default async function AuditionFeePage({
       } as TrainingProduct)
     : null
 
-  return <TrainingClient product={product} plans={plans} productSlug={PRODUCT_SLUG} paymentRef={ref} />
+  return (
+    <TrainingClient
+      product={product}
+      plans={plans}
+      productSlug={PRODUCT_SLUG}
+      paymentRef={ref}
+      copyOverride={AUDITION_FEE_COPY}
+    />
+  )
 }

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -70,11 +70,14 @@ export function TrainingClient({
   product,
   plans,
   productSlug,
+  paymentRef,
 }: {
   product: TrainingProduct | null
   plans: TrainingPlan[]
   // 생략하면 서버가 기존 트레이닝 패키지로 처리한다(기존 /training 동작 그대로).
   productSlug?: string
+  // deetz 비자 케이스에서 발급한 결제 링크 토큰(?ref=). 주문을 그 케이스에 연결한다.
+  paymentRef?: string
 }) {
   const router = useRouter()
   // 사이트 전역 언어 상태를 그대로 쓴다 (헤더 언어 선택과 연동).
@@ -110,7 +113,7 @@ export function TrainingClient({
       const response = await fetch('/api/training/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ planCode, productSlug, name, email, phone, nationality, memo, agreed, preferredLang: lang }),
+        body: JSON.stringify({ planCode, productSlug, ref: paymentRef, name, email, phone, nationality, memo, agreed, preferredLang: lang }),
       })
       const data = await response.json()
       if (!response.ok || !data.success) {

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -71,6 +71,7 @@ export function TrainingClient({
   plans,
   productSlug,
   paymentRef,
+  copyOverride,
 }: {
   product: TrainingProduct | null
   plans: TrainingPlan[]
@@ -78,6 +79,9 @@ export function TrainingClient({
   productSlug?: string
   // deetz 비자 케이스에서 발급한 결제 링크 토큰(?ref=). 주문을 그 케이스에 연결한다.
   paymentRef?: string
+  // 상품별 카피 덮어쓰기. 생략하면 트레이닝 패키지 기준값을 쓴다.
+  // 화면 언어는 클라이언트에서 결정되므로 언어별 맵으로 받는다.
+  copyOverride?: Record<TrainingLang, { process: { title: string; body: string }[]; servicePeriod: string }>
 }) {
   const router = useRouter()
   // 사이트 전역 언어 상태를 그대로 쓴다 (헤더 언어 선택과 연동).
@@ -157,7 +161,7 @@ export function TrainingClient({
             <h1 className="text-2xl font-bold text-zinc-950">{t.emptyTitle}</h1>
             <p className="mt-3 text-sm text-zinc-600">{t.emptyBody}</p>
           </div>
-          <MerchantInfoFooter lang={lang} />
+          <MerchantInfoFooter lang={lang} servicePeriod={copyOverride?.[lang]?.servicePeriod} />
         </main>
         <Footer />
       </>
@@ -207,7 +211,7 @@ export function TrainingClient({
             </div>
           </div>
           <div className="mt-8 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-            {t.process.map((step, index) => (
+            {(copyOverride?.[lang]?.process ?? t.process).map((step, index) => (
               <div key={step.title} className="border border-zinc-300 p-5">
                 <div className="font-mono text-xs font-semibold text-zinc-500">{String(index + 1).padStart(2, '0')}</div>
                 <h3 className="mt-3 text-lg font-bold text-zinc-950">{step.title}</h3>
@@ -469,7 +473,7 @@ export function TrainingClient({
           </div>
         </section>
 
-        <MerchantInfoFooter lang={lang} />
+        <MerchantInfoFooter lang={lang} servicePeriod={copyOverride?.[lang]?.servicePeriod} />
       </main>
       <Footer />
     </>

--- a/src/app/training/page.tsx
+++ b/src/app/training/page.tsx
@@ -18,7 +18,13 @@ export const metadata: Metadata = {
   },
 }
 
-export default async function TrainingPage() {
+export default async function TrainingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string }>
+}) {
+  // deetz 케이스에서 발급한 결제 링크 토큰. 검증은 서버(checkout)에서만 한다.
+  const { ref } = await searchParams
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -49,5 +55,5 @@ export default async function TrainingPage() {
       } as TrainingProduct)
     : null
 
-  return <TrainingClient product={product} plans={plans} />
+  return <TrainingClient product={product} plans={plans} paymentRef={ref} />
 }

--- a/src/components/payments/MerchantInfoFooter.tsx
+++ b/src/components/payments/MerchantInfoFooter.tsx
@@ -27,6 +27,8 @@ const COPY: Record<TrainingLang, {
   email: string
   bankAccount: string
   hours: string
+  servicePeriod: string
+  servicePeriodValue: string
   methods: string
   methodsValue: string
   notice: string
@@ -100,7 +102,14 @@ const COPY: Record<TrainingLang, {
   },
 }
 
-export function MerchantInfoFooter({ lang = 'ko' }: { lang?: TrainingLang }) {
+export function MerchantInfoFooter({
+  lang = 'ko',
+  servicePeriod,
+}: {
+  lang?: TrainingLang
+  // 상품마다 제공 기간이 다르다. 생략하면 트레이닝 패키지 기준(3~6개월).
+  servicePeriod?: string
+}) {
   const t = COPY[lang]
   const rows: [string, string][] = [
     [t.companyName, MERCHANT.companyName],
@@ -111,7 +120,7 @@ export function MerchantInfoFooter({ lang = 'ko' }: { lang?: TrainingLang }) {
     [t.email, MERCHANT.email],
     [t.hours, MERCHANT.hours],
     [t.bankAccount, MERCHANT.bankAccount],
-    [t.servicePeriod, t.servicePeriodValue],
+    [t.servicePeriod, servicePeriod || t.servicePeriodValue],
     [t.methods, t.methodsValue],
   ]
 

--- a/src/lib/training-package.ts
+++ b/src/lib/training-package.ts
@@ -345,3 +345,39 @@ export const TRAINING_COPY: Record<TrainingLang, {
     currencyNotice: '基本の決済通貨は韓国ウォン(KRW)です。PayPalのみウォンに対応していないため外貨で請求されます。',
   },
 }
+
+// 오디션 참석 확정비(/audition-fee) 전용 카피.
+// TRAINING_COPY 의 "진행 방식"은 트레이닝 패키지 4단계라 참가비 상품에는 맞지 않는다.
+// 서비스 제공 기간도 상품별로 다르므로 같이 둔다.
+export const AUDITION_FEE_COPY: Record<
+  TrainingLang,
+  { process: { title: string; body: string }[]; servicePeriod: string }
+> = {
+  ko: {
+    process: [
+      { title: '참가비 결제', body: '오디션 참석을 확정하기 위한 참가비를 결제합니다.' },
+      { title: '일정·장소 안내', body: '결제 확인 후 오디션 일시와 장소를 개별 안내드립니다.' },
+      { title: '오디션 참석', body: '안내받은 일정에 맞춰 오디션에 참석합니다.' },
+      { title: '결과 안내', body: '오디션 결과와 이후 진행 방식을 안내드립니다.' },
+    ],
+    servicePeriod: '결제일로부터 오디션 종료 시점까지 (일정은 개별 안내)',
+  },
+  en: {
+    process: [
+      { title: 'Pay the fee', body: 'Pay the fee that confirms your audition slot.' },
+      { title: 'Schedule sent', body: 'Once payment is confirmed we send you the date and venue.' },
+      { title: 'Attend', body: 'Attend the audition at the scheduled time.' },
+      { title: 'Result', body: 'We share the result and what happens next.' },
+    ],
+    servicePeriod: 'From the payment date until the audition is completed (schedule sent individually)',
+  },
+  ja: {
+    process: [
+      { title: '参加費のお支払い', body: 'オーディション参加を確定するための参加費をお支払いいただきます。' },
+      { title: '日程・会場のご案内', body: '入金確認後、オーディションの日時と会場を個別にご案内します。' },
+      { title: 'オーディション参加', body: 'ご案内した日程に合わせてオーディションにご参加ください。' },
+      { title: '結果のご案内', body: 'オーディション結果と今後の進め方をご案内します。' },
+    ],
+    servicePeriod: 'お支払い日からオーディション終了まで（日程は個別にご案内）',
+  },
+}

--- a/src/lib/visa-payment-ref.ts
+++ b/src/lib/visa-payment-ref.ts
@@ -1,0 +1,105 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+// deetz 비자 케이스 ↔ 이 결제 시스템을 잇는 서명 토큰.
+//
+// deetz 어드민이 결제 링크(?ref=…)를 발급하고, 여기서 검증해 주문에
+// visa_application_id 를 기록한다. 결제가 승인되면 deetz 로 결과를 돌려준다.
+// 원본 구현은 deetz 레포 src/lib/visa/payment-link.ts — 두 파일의 포맷은 항상 같이 바꾼다.
+//
+// 공유 비밀 VISA_PAYMENT_LINK_SECRET 은 양쪽 Vercel 에 동일 값으로 넣는다.
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const SLUG_RE = /^[a-z0-9-]{2,64}$/
+
+export type VisaPaymentRef = {
+  applicationId: string
+  productSlug: string
+}
+
+function sign(payload: string, key: string): string {
+  return createHmac('sha256', key).update(payload).digest('base64url')
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
+  return bufA.length === bufB.length && timingSafeEqual(bufA, bufB)
+}
+
+export function verifyVisaPaymentRef(token: string | null | undefined): VisaPaymentRef | null {
+  try {
+    if (!token) return null
+    const key = process.env.VISA_PAYMENT_LINK_SECRET
+    if (!key) return null
+    const dot = token.lastIndexOf('.')
+    if (dot < 1) return null
+    const payload = Buffer.from(token.slice(0, dot), 'base64url').toString('utf8')
+    if (!safeEqual(token.slice(dot + 1), sign(payload, key))) return null
+
+    const [prefix, applicationId, productSlug, expiresRaw] = payload.split(':')
+    if (prefix !== 'vp') return null
+    if (!UUID_RE.test(applicationId ?? '')) return null
+    if (!SLUG_RE.test(productSlug ?? '')) return null
+
+    const expiresAt = Number(expiresRaw)
+    if (!Number.isFinite(expiresAt) || expiresAt <= Math.floor(Date.now() / 1000)) return null
+
+    return { applicationId, productSlug }
+  } catch {
+    return null
+  }
+}
+
+type CallbackEvent = 'paid' | 'refunded'
+
+// 결제 결과를 deetz 케이스로 미러링한다.
+//
+// 실패해도 결제 자체는 이미 성공한 상태이므로 절대 throw 하지 않는다.
+// (돈은 받았는데 사용자에게 실패 화면을 보여주는 상황을 만들지 않는다.)
+// 누락분은 주문번호로 수기 대사가 가능하도록 실패를 로그에 남긴다.
+export async function notifyVisaCasePayment(input: {
+  applicationId: string
+  event: CallbackEvent
+  orderNo: string
+  provider: 'toss' | 'paypal'
+  amountKrw: number
+  occurredAt?: string
+  meta?: Record<string, unknown>
+}): Promise<boolean> {
+  const secret = process.env.VISA_PAYMENT_LINK_SECRET
+  if (!secret) {
+    console.error('[visa-payment-ref] VISA_PAYMENT_LINK_SECRET 미설정 — 콜백 생략', input.orderNo)
+    return false
+  }
+  const base = (process.env.DEETZ_SITE_URL || 'https://deetz.kr').replace(/\/$/, '')
+  const body = JSON.stringify({
+    applicationId: input.applicationId,
+    event: input.event,
+    orderNo: input.orderNo,
+    provider: input.provider,
+    amountKrw: input.amountKrw,
+    occurredAt: input.occurredAt ?? new Date().toISOString(),
+    meta: input.meta ?? {},
+  })
+
+  try {
+    const response = await fetch(`${base}/api/visa/payment-callback`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-visa-signature': sign(body, secret),
+      },
+      body,
+      // 결제 응답을 오래 붙잡지 않는다.
+      signal: AbortSignal.timeout(8000),
+    })
+    if (!response.ok) {
+      console.error('[visa-payment-ref] 콜백 실패', input.orderNo, response.status, await response.text())
+      return false
+    }
+    return true
+  } catch (error) {
+    console.error('[visa-payment-ref] 콜백 오류', input.orderNo, error)
+    return false
+  }
+}


### PR DESCRIPTION
deetz PR과 **한 세트**입니다: tkaykim/dancers-bio `feat/visa-payment-link`

## 왜

지원 → 일정 조율 → 미팅 → 오디션까지는 deetz 케이스에 남는데,
그다음 결제는 grigoent 에만 있어서 운영자가 "이 사람 결제했나"를 알 수 없었습니다.
`training_orders.visa_application_id` 컬럼은 있었지만 아무도 채우지 않고 있었습니다.

## 무엇

1. deetz 어드민이 결제 링크 `?ref=<서명토큰>` 발급
2. checkout 이 토큰을 검증해 `visa_application_id` 저장
3. 결제 승인(토스/PayPal) 시 deetz `/api/visa/payment-callback` 으로 통보
4. deetz 케이스가 `paid` 로 바뀌고 어드민에 표시

## 설계 판단

**토큰이 만료·불일치여도 결제는 막지 않습니다.** 케이스 연결만 포기합니다.
링크 만료 때문에 결제를 못 하게 만들면 매출을 잃고, 연결은 주문번호로 수기 복구가 됩니다.

**콜백 실패가 결제 응답을 막지 않습니다.** 결제는 이미 승인된 상태이므로,
돈은 받았는데 사용자에게 실패 화면을 보여주는 상황을 만들지 않습니다. 실패는 로그에 남깁니다.

## 배포 전 필요

- `VISA_PAYMENT_LINK_SECRET` 양쪽 Vercel 에 동일 값 (등록 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)