### PR TITLE
feat(admin): 결제 취소·환불 기능

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -16,7 +16,7 @@ import { toast } from 'sonner'
 import Papa from 'papaparse';
 import { Tabs as UITabs, TabsList as UITabsList, TabsTrigger as UITabsTrigger, TabsContent as UITabsContent } from '@/components/ui/tabs';
 import { SEOSettingsManager } from '@/components/dashboard/SEOSettingsManager';
-import { AlertTriangle, Users, UserCheck, FileText, Link, Receipt, Scale, UserPlus, BriefcaseBusiness } from 'lucide-react'
+import { AlertTriangle, Users, UserCheck, FileText, Link, Receipt, Scale, UserPlus, BriefcaseBusiness, CreditCard } from 'lucide-react'
 import { ClaimRequestModal } from '@/components/proposals/ClaimRequestModal'
 import { DirectLinkModal } from '@/components/proposals/DirectLinkModal'
 
@@ -846,6 +846,9 @@ export default function AdminPage() {
               <TabsTrigger value="fee-reports">
                 미수 제보
               </TabsTrigger>
+              <TabsTrigger value="training-orders">
+                결제 주문
+              </TabsTrigger>
               <TabsTrigger value="quotes">
                 견적서
               </TabsTrigger>
@@ -1265,6 +1268,36 @@ export default function AdminPage() {
                     >
                       <Scale className="w-4 h-4" />
                       미수·정산 제보 관리로 이동
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            <TabsContent value="training-orders">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <CreditCard className="w-5 h-5" />
+                    결제 주문
+                  </CardTitle>
+                  <p className="text-sm text-zinc-600">
+                    결제 내역을 확인하고 취소·환불을 처리합니다
+                  </p>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-center py-12">
+                    <CreditCard className="w-16 h-16 text-zinc-400 mx-auto mb-4" />
+                    <h3 className="text-lg font-medium text-zinc-900 mb-2">결제 주문</h3>
+                    <p className="text-zinc-600 mb-6">
+                      토스페이먼츠·PayPal 결제 건을 조회하고 환불할 수 있습니다.
+                    </p>
+                    <Button
+                      onClick={() => router.push('/admin/training-orders')}
+                      className="flex items-center gap-2"
+                    >
+                      <CreditCard className="w-4 h-4" />
+                      결제 주문 관리로 이동
                     </Button>
                   </div>
                 </CardContent>

--- a/src/app/admin/training-orders/page.tsx
+++ b/src/app/admin/training-orders/page.tsx
@@ -1,0 +1,324 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Header } from '@/components/layout/Header'
+import { Footer } from '@/components/layout/Footer'
+import { useAuth } from '@/contexts/AuthContext'
+import { supabase } from '@/lib/supabase'
+import { Button } from '@/components/ui/button'
+
+// 결제 주문 조회 + 취소·환불.
+//
+// 환불은 PG(토스/PayPal)에 실제로 취소를 걸고, 성공했을 때만 DB를 바꾼다.
+// PayPal 은 외화 결제라 부분환불을 막아뒀다(원화 기준 금액이 환율 때문에 어긋난다).
+
+type Payment = {
+  id: string
+  sequence: number
+  amount: number
+  currency: string
+  status: string
+  pg_provider: string | null
+  payment_key: string | null
+  paid_at: string | null
+  receipt_url: string | null
+  failure_reason: string | null
+}
+
+type Order = {
+  id: string
+  order_no: string
+  customer_name: string
+  customer_email: string
+  customer_phone: string | null
+  customer_nationality: string | null
+  total_amount: number
+  paid_amount: number
+  status: string
+  pg_provider: string | null
+  visa_application_id: string | null
+  memo: string | null
+  created_at: string
+  payments: Payment[]
+}
+
+const ORDER_STATUS_LABEL: Record<string, string> = {
+  pending: '결제 대기',
+  active: '결제 진행',
+  completed: '결제 완료',
+  refunded: '환불됨',
+}
+
+const PROVIDER_LABEL: Record<string, string> = { toss: '토스페이먼츠', paypal: 'PayPal' }
+
+function krw(value: number): string {
+  return `${value.toLocaleString('ko-KR')}원`
+}
+
+function formatKst(value: string | null): string {
+  if (!value) return '-'
+  try {
+    return new Intl.DateTimeFormat('ko-KR', {
+      timeZone: 'Asia/Seoul',
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(new Date(value))
+  } catch {
+    return value
+  }
+}
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session?.access_token) throw new Error('no_session')
+  return { Authorization: `Bearer ${session.access_token}` }
+}
+
+export default function AdminTrainingOrdersPage() {
+  const { profile, loading: authLoading } = useAuth()
+  const router = useRouter()
+  const isAdmin = profile?.type === 'admin'
+
+  const [items, setItems] = useState<Order[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [refundingId, setRefundingId] = useState<string | null>(null)
+  const [notice, setNotice] = useState('')
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/admin/training-orders', {
+        cache: 'no-store',
+        headers: await authHeaders(),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'failed')
+      setItems(json.items || [])
+      setError('')
+    } catch {
+      setError('목록을 불러오지 못했습니다. 관리자 계정으로 로그인했는지 확인해 주세요.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (authLoading) return
+    if (!isAdmin) {
+      setLoading(false)
+      return
+    }
+    load()
+  }, [authLoading, isAdmin, load])
+
+  const refund = async (order: Order, payment: Payment, partial: boolean) => {
+    const max = payment.amount
+    let amount: number | undefined
+    if (partial) {
+      const input = window.prompt(
+        `부분환불 금액을 입력하세요 (최대 ${max.toLocaleString('ko-KR')}원)`,
+        String(max),
+      )
+      if (!input) return
+      amount = Number(input.replace(/[^0-9]/g, ''))
+      if (!amount || amount <= 0 || amount > max) {
+        window.alert('환불 금액을 확인해 주세요.')
+        return
+      }
+    }
+
+    const reason = window.prompt('취소 사유를 입력하세요.', '고객 요청')
+    if (!reason) return
+
+    const label = amount ? `${amount.toLocaleString('ko-KR')}원 부분환불` : `${krw(max)} 전액 환불`
+    if (
+      !window.confirm(
+        `${order.order_no} / ${order.customer_name}\n${label}\n\n실제로 결제가 취소됩니다. 진행할까요?`,
+      )
+    ) {
+      return
+    }
+
+    setRefundingId(payment.id)
+    setNotice('')
+    try {
+      const res = await fetch('/api/admin/training-orders/refund', {
+        method: 'POST',
+        headers: { ...(await authHeaders()), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ paymentId: payment.id, reason, amount }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || '환불에 실패했습니다.')
+      setNotice(
+        `${order.order_no} 환불 완료 — ${krw(json.refundedAmount)}${
+          json.partial ? ' (부분환불)' : ''
+        }`,
+      )
+      await load()
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : '환불에 실패했습니다.')
+    } finally {
+      setRefundingId(null)
+    }
+  }
+
+  if (!authLoading && !isAdmin) {
+    return (
+      <div>
+        <Header />
+        <main className="flex min-h-screen items-center justify-center px-4 pt-16">
+          <p className="text-zinc-600">관리자만 접근할 수 있습니다.</p>
+        </main>
+        <Footer />
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <Header />
+      <main className="min-h-screen bg-zinc-50 pt-16">
+        <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+          <div className="mb-8 flex items-center justify-between gap-4">
+            <h1 className="text-2xl font-bold text-zinc-900">결제 주문</h1>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={load}>
+                새로고침
+              </Button>
+              <Button variant="outline" onClick={() => router.push('/admin')}>
+                관리자 홈
+              </Button>
+            </div>
+          </div>
+
+          {notice ? (
+            <p className="mb-4 border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-800">
+              {notice}
+            </p>
+          ) : null}
+          {error ? (
+            <p className="mb-4 border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</p>
+          ) : null}
+
+          {loading ? (
+            <p className="text-sm text-zinc-500">불러오는 중…</p>
+          ) : items.length === 0 ? (
+            <p className="text-sm text-zinc-500">주문이 없습니다.</p>
+          ) : (
+            <div className="space-y-4">
+              {items.map((order) => (
+                <div key={order.id} className="border border-zinc-200 bg-white p-5">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="font-mono text-sm font-semibold text-zinc-900">
+                        {order.order_no}
+                      </p>
+                      <p className="mt-1 text-sm text-zinc-700">
+                        {order.customer_name} · {order.customer_email}
+                        {order.customer_phone ? ` · ${order.customer_phone}` : ''}
+                        {order.customer_nationality ? ` · ${order.customer_nationality}` : ''}
+                      </p>
+                      <p className="mt-1 text-xs text-zinc-500">{formatKst(order.created_at)}</p>
+                    </div>
+                    <div className="text-right">
+                      <span className="inline-block bg-zinc-100 px-2.5 py-1 text-xs font-semibold text-zinc-700">
+                        {ORDER_STATUS_LABEL[order.status] ?? order.status}
+                      </span>
+                      <p className="mt-2 text-sm text-zinc-900">
+                        {krw(order.paid_amount)} / {krw(order.total_amount)}
+                      </p>
+                      {order.visa_application_id ? (
+                        <p className="mt-1 text-xs text-sky-700">deetz 비자 케이스 연결됨</p>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  {order.memo ? (
+                    <p className="mt-3 whitespace-pre-line border-l-2 border-zinc-200 pl-3 text-xs text-zinc-600">
+                      {order.memo}
+                    </p>
+                  ) : null}
+
+                  <div className="mt-4 space-y-2">
+                    {order.payments.map((payment) => (
+                      <div
+                        key={payment.id}
+                        className="flex flex-wrap items-center justify-between gap-3 border border-zinc-200 bg-zinc-50 px-3 py-2.5"
+                      >
+                        <div className="text-xs text-zinc-700">
+                          <span className="font-semibold">{payment.sequence}회차</span>
+                          <span className="mx-2 text-zinc-400">·</span>
+                          {krw(payment.amount)}
+                          <span className="mx-2 text-zinc-400">·</span>
+                          {payment.status === 'paid'
+                            ? '결제 완료'
+                            : payment.status === 'refunded'
+                              ? '환불됨'
+                              : '대기'}
+                          {payment.pg_provider ? (
+                            <>
+                              <span className="mx-2 text-zinc-400">·</span>
+                              {PROVIDER_LABEL[payment.pg_provider] ?? payment.pg_provider}
+                            </>
+                          ) : null}
+                          {payment.paid_at ? (
+                            <>
+                              <span className="mx-2 text-zinc-400">·</span>
+                              {formatKst(payment.paid_at)}
+                            </>
+                          ) : null}
+                          {payment.failure_reason ? (
+                            <p className="mt-1 text-zinc-500">{payment.failure_reason}</p>
+                          ) : null}
+                        </div>
+
+                        <div className="flex flex-wrap gap-2">
+                          {payment.receipt_url ? (
+                            <a
+                              href={payment.receipt_url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="border border-zinc-300 bg-white px-2.5 py-1.5 text-xs text-zinc-700 hover:border-zinc-500"
+                            >
+                              영수증
+                            </a>
+                          ) : null}
+                          {payment.status === 'paid' ? (
+                            <>
+                              {payment.pg_provider === 'toss' ? (
+                                <button
+                                  type="button"
+                                  disabled={refundingId === payment.id}
+                                  onClick={() => refund(order, payment, true)}
+                                  className="border border-zinc-300 bg-white px-2.5 py-1.5 text-xs text-zinc-700 transition hover:border-zinc-500 disabled:opacity-50"
+                                >
+                                  부분환불
+                                </button>
+                              ) : null}
+                              <button
+                                type="button"
+                                disabled={refundingId === payment.id}
+                                onClick={() => refund(order, payment, false)}
+                                className="bg-red-600 px-2.5 py-1.5 text-xs font-semibold text-white transition hover:bg-red-700 disabled:opacity-50"
+                              >
+                                {refundingId === payment.id ? '처리 중…' : '전액 환불'}
+                              </button>
+                            </>
+                          ) : null}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/app/api/admin/training-orders/refund/route.ts
+++ b/src/app/api/admin/training-orders/refund/route.ts
@@ -1,0 +1,213 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { assertAdminFromRequest } from '@/lib/admin-auth'
+import { tossSecretKey } from '@/lib/toss-keys'
+import { notifyVisaCasePayment } from '@/lib/visa-payment-ref'
+
+// 결제 취소·환불.
+//
+// 회차(training_order_payments) 단위로 취소한다. PG 취소가 성공한 뒤에만 DB를 바꾼다.
+// 순서를 뒤집으면 "우리 DB는 환불됨인데 실제로는 돈이 안 나간" 상태가 생긴다.
+//
+// 부분환불은 토스만 지원한다. PayPal 은 원화가 아니라 외화로 청구돼서
+// 원화 기준 부분환불 금액을 외화로 환산하면 환율 때문에 금액이 어긋난다 — 전액만 허용한다.
+
+function getServiceRole() {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+}
+
+type Body = {
+  paymentId?: string
+  reason?: string
+  /** 부분환불 금액(원). 생략하면 전액. 토스만 지원. */
+  amount?: number
+}
+
+const PAYPAL_API_URL =
+  process.env.NEXT_PUBLIC_PAYPAL_SANDBOX === 'true'
+    ? 'https://api-m.sandbox.paypal.com'
+    : 'https://api-m.paypal.com'
+
+async function paypalAccessToken(): Promise<string> {
+  const id = process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID
+  const secret = process.env.PAYPAL_CLIENT_SECRET
+  if (!id || !secret) throw new Error('PayPal 키가 설정되지 않았습니다.')
+  const response = await fetch(`${PAYPAL_API_URL}/v1/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${id}:${secret}`).toString('base64')}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: 'grant_type=client_credentials',
+  })
+  const data = await response.json()
+  if (!response.ok) throw new Error(data?.error_description || 'PayPal 인증 실패')
+  return data.access_token as string
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await assertAdminFromRequest(request, 'training-orders')
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error, detail: auth.detail }, { status: auth.status })
+  }
+
+  try {
+    const body = (await request.json()) as Body
+    const paymentId = (body.paymentId ?? '').trim()
+    const reason = (body.reason ?? '').trim() || '관리자 취소'
+    if (!paymentId) {
+      return NextResponse.json({ error: '결제 건을 선택해 주세요.' }, { status: 400 })
+    }
+
+    const svc = getServiceRole()
+    const { data: payment, error: paymentError } = await svc
+      .from('training_order_payments')
+      .select('id, order_id, sequence, amount, status, pg_provider, payment_key, raw')
+      .eq('id', paymentId)
+      .maybeSingle()
+
+    if (paymentError || !payment) {
+      return NextResponse.json({ error: '결제 건을 찾을 수 없습니다.' }, { status: 404 })
+    }
+    if (payment.status !== 'paid') {
+      return NextResponse.json({ error: '결제 완료 상태가 아닙니다.' }, { status: 400 })
+    }
+
+    const paidAmount = payment.amount as number
+    const requested = Number.isFinite(body.amount) ? Math.floor(body.amount as number) : paidAmount
+    if (requested <= 0 || requested > paidAmount) {
+      return NextResponse.json({ error: '환불 금액을 확인해 주세요.' }, { status: 400 })
+    }
+    const isPartial = requested < paidAmount
+
+    let pgResult: unknown = null
+
+    // --- PG 취소 (실패하면 여기서 끝. DB는 건드리지 않는다) ---
+    if (payment.pg_provider === 'toss') {
+      if (!payment.payment_key) {
+        return NextResponse.json({ error: '토스 결제키가 없어 취소할 수 없습니다.' }, { status: 400 })
+      }
+      const response = await fetch(
+        `https://api.tosspayments.com/v1/payments/${payment.payment_key}/cancel`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Basic ${Buffer.from(`${tossSecretKey()}:`).toString('base64')}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(
+            isPartial ? { cancelReason: reason, cancelAmount: requested } : { cancelReason: reason },
+          ),
+        },
+      )
+      pgResult = await response.json()
+      if (!response.ok) {
+        const message =
+          (pgResult as { message?: string })?.message ?? '토스 결제 취소에 실패했습니다.'
+        console.error('[training/refund] toss cancel failed:', pgResult)
+        return NextResponse.json({ error: message }, { status: 502 })
+      }
+    } else if (payment.pg_provider === 'paypal') {
+      if (isPartial) {
+        return NextResponse.json(
+          { error: 'PayPal 은 외화 결제라 부분환불을 지원하지 않습니다. 전액 환불만 가능합니다.' },
+          { status: 400 },
+        )
+      }
+      // 승인 시 payment_key 에 캡처 ID를 저장한다. 없으면 원본 응답에서 찾는다.
+      const raw = payment.raw as
+        | { purchase_units?: { payments?: { captures?: { id?: string }[] } }[] }
+        | null
+      const captureId =
+        (payment.payment_key as string | null) ?? raw?.purchase_units?.[0]?.payments?.captures?.[0]?.id
+      if (!captureId) {
+        return NextResponse.json(
+          { error: 'PayPal 캡처 ID를 찾을 수 없습니다. PayPal 콘솔에서 직접 환불해 주세요.' },
+          { status: 400 },
+        )
+      }
+      const token = await paypalAccessToken()
+      const response = await fetch(`${PAYPAL_API_URL}/v2/payments/captures/${captureId}/refund`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note_to_payer: reason.slice(0, 255) }),
+      })
+      pgResult = await response.json()
+      if (!response.ok) {
+        const message =
+          (pgResult as { message?: string })?.message ?? 'PayPal 환불에 실패했습니다.'
+        console.error('[training/refund] paypal refund failed:', pgResult)
+        return NextResponse.json({ error: message }, { status: 502 })
+      }
+    } else {
+      return NextResponse.json(
+        { error: `자동 환불을 지원하지 않는 결제수단입니다: ${payment.pg_provider ?? '미상'}` },
+        { status: 400 },
+      )
+    }
+
+    // --- 여기부터는 실제로 돈이 나간 상태. DB 갱신 실패해도 환불은 유효하다. ---
+    const refundedAt = new Date().toISOString()
+    const remaining = paidAmount - requested
+
+    await svc
+      .from('training_order_payments')
+      .update({
+        // 부분환불이면 남은 금액이 있으므로 paid 를 유지하고 금액만 줄인다.
+        status: isPartial ? 'paid' : 'refunded',
+        amount: remaining,
+        failure_reason: isPartial ? `부분환불 ${requested.toLocaleString('ko-KR')}원: ${reason}` : reason,
+        raw: pgResult,
+        updated_at: refundedAt,
+      })
+      .eq('id', payment.id)
+
+    const { data: order } = await svc
+      .from('training_orders')
+      .select('id, order_no, total_amount, visa_application_id')
+      .eq('id', payment.order_id)
+      .maybeSingle()
+
+    const { data: paidRows } = await svc
+      .from('training_order_payments')
+      .select('amount')
+      .eq('order_id', payment.order_id)
+      .eq('status', 'paid')
+
+    const newPaidAmount = (paidRows ?? []).reduce((sum, row) => sum + (row.amount as number), 0)
+
+    await svc
+      .from('training_orders')
+      .update({
+        paid_amount: newPaidAmount,
+        status: newPaidAmount <= 0 ? 'refunded' : newPaidAmount >= (order?.total_amount ?? 0) ? 'completed' : 'active',
+        updated_at: refundedAt,
+      })
+      .eq('id', payment.order_id)
+
+    // 전액 환불로 주문에 남은 결제가 없어졌을 때만 케이스에 알린다.
+    // 부분환불은 여전히 "결제된 상태"라 케이스를 환불로 뒤집으면 오히려 틀린다.
+    if (order?.visa_application_id && order.order_no && newPaidAmount <= 0) {
+      await notifyVisaCasePayment({
+        applicationId: order.visa_application_id as string,
+        event: 'refunded',
+        orderNo: order.order_no,
+        provider: payment.pg_provider as 'toss' | 'paypal',
+        amountKrw: requested,
+        occurredAt: refundedAt,
+        meta: { reason, sequence: payment.sequence },
+      })
+    }
+
+    return NextResponse.json({
+      success: true,
+      refundedAmount: requested,
+      remainingPaidAmount: newPaidAmount,
+      partial: isPartial,
+    })
+  } catch (error) {
+    console.error('[training/refund] unexpected error:', error)
+    const message = error instanceof Error ? error.message : '환불 처리 중 오류가 발생했습니다.'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/training-orders/route.ts
+++ b/src/app/api/admin/training-orders/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { assertAdminFromRequest } from '@/lib/admin-auth'
+
+// 결제 주문 목록 (관리자). 환불 화면의 데이터 소스.
+export async function GET(request: NextRequest) {
+  const auth = await assertAdminFromRequest(request, 'training-orders')
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error, detail: auth.detail }, { status: auth.status })
+  }
+
+  const svc = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  )
+
+  const { data: orders, error } = await svc
+    .from('training_orders')
+    .select(
+      'id, order_no, customer_name, customer_email, customer_phone, customer_nationality, currency, total_amount, paid_amount, status, pg_provider, visa_application_id, memo, created_at',
+    )
+    .order('created_at', { ascending: false })
+    .limit(200)
+
+  if (error) {
+    console.error('[admin/training-orders] list failed:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const orderIds = (orders ?? []).map((row) => row.id as string)
+  const { data: payments } = orderIds.length
+    ? await svc
+        .from('training_order_payments')
+        .select(
+          'id, order_id, sequence, amount, currency, status, pg_provider, payment_key, paid_at, receipt_url, failure_reason',
+        )
+        .in('order_id', orderIds)
+        .order('sequence', { ascending: true })
+    : { data: [] }
+
+  const byOrder = new Map<string, unknown[]>()
+  for (const payment of payments ?? []) {
+    const key = payment.order_id as string
+    if (!byOrder.has(key)) byOrder.set(key, [])
+    byOrder.get(key)!.push(payment)
+  }
+
+  return NextResponse.json({
+    items: (orders ?? []).map((order) => ({
+      ...order,
+      payments: byOrder.get(order.id as string) ?? [],
+    })),
+  })
+}


### PR DESCRIPTION
## 왜

환불 기능이 없어서 토스/PayPal 콘솔에서 직접 환불하고 DB를 수기로 맞춰야 했습니다.

## 무엇

- `/admin/training-orders` — 주문 목록, 회차별 결제 상태, 영수증 링크
- 전액 환불 (토스 + PayPal)
- 부분 환불 (토스만)

## 설계 판단

**PG 취소가 성공한 뒤에만 DB를 바꿉니다.**
순서를 뒤집으면 "DB는 환불됨인데 실제로는 돈이 안 나간" 상태가 생깁니다.

**PayPal 부분환불은 막았습니다.**
외화로 청구되기 때문에 원화 기준 부분금액을 환산하면 환율 때문에 금액이 어긋납니다.
전액 환불만 허용합니다.

**전액 환불로 주문의 결제가 0이 될 때만 deetz 케이스에 통보합니다.**
부분환불은 여전히 결제된 상태라, 케이스를 `refunded` 로 뒤집으면 오히려 틀린 정보가 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)