### PR TITLE
feat(payments): 두 결제 페이지 공통 할인코드

### DIFF
--- a/db/migrations/20260815_001_training_discount_codes.sql
+++ b/db/migrations/20260815_001_training_discount_codes.sql
@@ -1,0 +1,125 @@
+-- 결제 페이지(/training, /audition-fee) 공통 할인코드.
+--
+-- 타입 명명은 modoo(coupons.discount_type)와 맞춘다: percentage | fixed_amount.
+-- 사업부가 달라도 같은 개념을 다른 이름으로 부르면 나중에 통합 조회가 안 된다.
+
+create table if not exists public.training_discount_codes (
+  id uuid primary key default gen_random_uuid(),
+  -- 항상 대문자로 저장한다. 입력은 대소문자 구분 없이 받고 서버에서 upper() 한다.
+  code text not null unique,
+  display_name text not null,
+  description text,
+  discount_type text not null check (discount_type in ('percentage', 'fixed_amount')),
+  -- percentage 면 0~100, fixed_amount 면 원 단위.
+  discount_value integer not null check (discount_value > 0),
+  -- percentage 할인의 상한(원). null 이면 상한 없음.
+  max_discount_amount integer,
+  -- 이 금액 이상 주문에만 적용.
+  min_order_amount integer not null default 0,
+  -- 사용 가능 횟수. null 이면 무제한.
+  max_uses integer,
+  -- 적용 대상 상품 slug. null 이면 전 상품.
+  product_slugs text[],
+  is_active boolean not null default true,
+  starts_at timestamptz,
+  expires_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- 사용 이력. 사용 횟수는 이 테이블의 행 수로 센다(코드 테이블에 카운터를 두면 어긋난다).
+--
+-- (code_id, customer_email) 유니크가 핵심이다.
+-- 같은 사람이 결제를 중단했다가 다시 시도하면 자기 슬롯을 재사용하고,
+-- 다른 사람이 한도를 넘겨 쓰려 하면 막힌다.
+create table if not exists public.training_discount_redemptions (
+  id uuid primary key default gen_random_uuid(),
+  code_id uuid not null references public.training_discount_codes(id) on delete cascade,
+  customer_email text not null,
+  -- 가장 최근에 이 코드를 적용한 주문.
+  order_id uuid references public.training_orders(id) on delete set null,
+  discount_amount integer not null default 0,
+  -- 결제가 실제로 승인된 시각. null 이면 아직 결제 전(예약 상태).
+  confirmed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (code_id, customer_email)
+);
+
+create index if not exists training_discount_redemptions_code_idx
+  on public.training_discount_redemptions (code_id);
+create index if not exists training_discount_redemptions_order_idx
+  on public.training_discount_redemptions (order_id);
+
+-- 주문에 적용된 할인 스냅샷. 코드가 나중에 수정·삭제돼도 주문 기록은 남아야 한다.
+alter table public.training_orders
+  add column if not exists discount_code text,
+  add column if not exists discount_amount integer not null default 0,
+  add column if not exists original_amount integer;
+
+-- 코드 예약(=사용 슬롯 확보)을 한 트랜잭션에서 원자적으로 처리한다.
+-- 애플리케이션에서 "센 다음 넣기"로 하면 동시 요청에 한도를 넘길 수 있다.
+create or replace function public.reserve_training_discount(
+  p_code text,
+  p_email text,
+  p_order_id uuid,
+  p_discount_amount integer
+) returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_code public.training_discount_codes%rowtype;
+  v_used integer;
+  v_existing uuid;
+  v_id uuid;
+begin
+  select * into v_code
+  from public.training_discount_codes
+  where code = upper(trim(p_code))
+  for update;
+
+  if not found then
+    raise exception 'DISCOUNT_NOT_FOUND';
+  end if;
+
+  select id into v_existing
+  from public.training_discount_redemptions
+  where code_id = v_code.id and customer_email = lower(trim(p_email));
+
+  -- 같은 이메일이 이미 슬롯을 갖고 있으면 한도 검사 없이 갱신한다(재시도 허용).
+  if v_existing is not null then
+    update public.training_discount_redemptions
+    set order_id = p_order_id,
+        discount_amount = p_discount_amount,
+        updated_at = now()
+    where id = v_existing
+    returning id into v_id;
+    return v_id;
+  end if;
+
+  if v_code.max_uses is not null then
+    select count(*) into v_used
+    from public.training_discount_redemptions
+    where code_id = v_code.id;
+
+    if v_used >= v_code.max_uses then
+      raise exception 'DISCOUNT_EXHAUSTED';
+    end if;
+  end if;
+
+  insert into public.training_discount_redemptions (code_id, customer_email, order_id, discount_amount)
+  values (v_code.id, lower(trim(p_email)), p_order_id, p_discount_amount)
+  returning id into v_id;
+
+  return v_id;
+end;
+$$;
+
+alter table public.training_discount_codes enable row level security;
+alter table public.training_discount_redemptions enable row level security;
+
+-- 서비스 롤(서버)만 접근한다. 코드 목록이 공개되면 무단 사용된다.
+drop policy if exists training_discount_codes_no_public on public.training_discount_codes;
+drop policy if exists training_discount_redemptions_no_public on public.training_discount_redemptions;

--- a/src/app/admin/discount-codes/page.tsx
+++ b/src/app/admin/discount-codes/page.tsx
@@ -1,0 +1,378 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Header } from '@/components/layout/Header'
+import { Footer } from '@/components/layout/Footer'
+import { useAuth } from '@/contexts/AuthContext'
+import { supabase } from '@/lib/supabase'
+import { Button } from '@/components/ui/button'
+
+// 할인코드 등록·관리.
+// 사용 횟수는 사용 이력 행 수로 표시한다(예약분 포함) — 결제 완료 건은 따로 센다.
+
+type Usage = { total: number; confirmed: number }
+
+type Code = {
+  id: string
+  code: string
+  display_name: string
+  description: string | null
+  discount_type: 'percentage' | 'fixed_amount'
+  discount_value: number
+  max_discount_amount: number | null
+  min_order_amount: number
+  max_uses: number | null
+  product_slugs: string[] | null
+  is_active: boolean
+  expires_at: string | null
+  created_at: string
+  usage: Usage
+}
+
+const PRODUCT_LABEL: Record<string, string> = {
+  'training-and-placement': '트레이닝 패키지',
+  'audition-fee': '오디션 참가비',
+}
+
+function krw(value: number): string {
+  return `${value.toLocaleString('ko-KR')}원`
+}
+
+function describe(code: Code): string {
+  if (code.discount_type === 'percentage') {
+    return code.max_discount_amount
+      ? `${code.discount_value}% (최대 ${krw(code.max_discount_amount)})`
+      : `${code.discount_value}%`
+  }
+  return krw(code.discount_value)
+}
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session?.access_token) throw new Error('no_session')
+  return { Authorization: `Bearer ${session.access_token}` }
+}
+
+const EMPTY_FORM = {
+  code: '',
+  displayName: '',
+  description: '',
+  discountType: 'fixed_amount' as 'percentage' | 'fixed_amount',
+  discountValue: '',
+  maxDiscountAmount: '',
+  minOrderAmount: '',
+  maxUses: '1',
+  productSlugs: [] as string[],
+  expiresAt: '',
+}
+
+export default function AdminDiscountCodesPage() {
+  const { profile, loading: authLoading } = useAuth()
+  const router = useRouter()
+  const isAdmin = profile?.type === 'admin'
+
+  const [items, setItems] = useState<Code[]>([])
+  const [productSlugs, setProductSlugs] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [form, setForm] = useState(EMPTY_FORM)
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/admin/discount-codes', {
+        cache: 'no-store',
+        headers: await authHeaders(),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'failed')
+      setItems(json.items || [])
+      setProductSlugs(json.productSlugs || [])
+      setError('')
+    } catch {
+      setError('목록을 불러오지 못했습니다. 관리자 계정으로 로그인했는지 확인해 주세요.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (authLoading) return
+    if (!isAdmin) {
+      setLoading(false)
+      return
+    }
+    load()
+  }, [authLoading, isAdmin, load])
+
+  const create = async () => {
+    setSaving(true)
+    setNotice('')
+    try {
+      const res = await fetch('/api/admin/discount-codes', {
+        method: 'POST',
+        headers: { ...(await authHeaders()), 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: form.code,
+          displayName: form.displayName,
+          description: form.description,
+          discountType: form.discountType,
+          discountValue: Number(form.discountValue),
+          maxDiscountAmount: form.maxDiscountAmount ? Number(form.maxDiscountAmount) : null,
+          minOrderAmount: form.minOrderAmount ? Number(form.minOrderAmount) : 0,
+          maxUses: form.maxUses ? Number(form.maxUses) : null,
+          productSlugs: form.productSlugs.length > 0 ? form.productSlugs : null,
+          expiresAt: form.expiresAt || null,
+        }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || '등록에 실패했습니다.')
+      setNotice(`${json.item.code} 등록 완료`)
+      setForm(EMPTY_FORM)
+      await load()
+    } catch (err) {
+      window.alert(err instanceof Error ? err.message : '등록에 실패했습니다.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const toggle = async (code: Code) => {
+    try {
+      const res = await fetch('/api/admin/discount-codes', {
+        method: 'PATCH',
+        headers: { ...(await authHeaders()), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: code.id, isActive: !code.is_active }),
+      })
+      if (!res.ok) throw new Error()
+      await load()
+    } catch {
+      window.alert('변경에 실패했습니다.')
+    }
+  }
+
+  if (!authLoading && !isAdmin) {
+    return (
+      <div>
+        <Header />
+        <main className="flex min-h-screen items-center justify-center px-4 pt-16">
+          <p className="text-zinc-600">관리자만 접근할 수 있습니다.</p>
+        </main>
+        <Footer />
+      </div>
+    )
+  }
+
+  const labelClass = 'mb-1.5 block text-xs font-semibold text-zinc-700'
+  const inputClass =
+    'min-h-10 w-full border border-zinc-300 bg-white px-3 text-sm text-zinc-950 outline-none focus:border-zinc-950'
+
+  return (
+    <div>
+      <Header />
+      <main className="min-h-screen bg-zinc-50 pt-16">
+        <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
+          <div className="mb-8 flex items-center justify-between gap-4">
+            <h1 className="text-2xl font-bold text-zinc-900">할인코드</h1>
+            <Button variant="outline" onClick={() => router.push('/admin')}>
+              관리자 홈
+            </Button>
+          </div>
+
+          {notice ? (
+            <p className="mb-4 border border-emerald-300 bg-emerald-50 p-3 text-sm text-emerald-800">
+              {notice}
+            </p>
+          ) : null}
+          {error ? (
+            <p className="mb-4 border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</p>
+          ) : null}
+
+          <section className="mb-10 border border-zinc-200 bg-white p-5">
+            <h2 className="mb-4 text-base font-bold text-zinc-900">새 할인코드 등록</h2>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className={labelClass}>코드 *</label>
+                <input
+                  value={form.code}
+                  onChange={(e) => setForm({ ...form, code: e.target.value.toUpperCase() })}
+                  placeholder="PEACEMAKER2026"
+                  className={`${inputClass} uppercase tracking-wide`}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>표시 이름 *</label>
+                <input
+                  value={form.displayName}
+                  onChange={(e) => setForm({ ...form, displayName: e.target.value })}
+                  placeholder="파트너 특별 할인"
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>할인 방식 *</label>
+                <select
+                  value={form.discountType}
+                  onChange={(e) =>
+                    setForm({ ...form, discountType: e.target.value as 'percentage' | 'fixed_amount' })
+                  }
+                  className={inputClass}
+                >
+                  <option value="fixed_amount">금액 할인 (원)</option>
+                  <option value="percentage">퍼센트 할인 (%)</option>
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>
+                  할인 값 * {form.discountType === 'percentage' ? '(%)' : '(원)'}
+                </label>
+                <input
+                  type="number"
+                  value={form.discountValue}
+                  onChange={(e) => setForm({ ...form, discountValue: e.target.value })}
+                  placeholder={form.discountType === 'percentage' ? '10' : '3000000'}
+                  className={inputClass}
+                />
+              </div>
+              {form.discountType === 'percentage' ? (
+                <div>
+                  <label className={labelClass}>최대 할인 금액 (원, 선택)</label>
+                  <input
+                    type="number"
+                    value={form.maxDiscountAmount}
+                    onChange={(e) => setForm({ ...form, maxDiscountAmount: e.target.value })}
+                    className={inputClass}
+                  />
+                </div>
+              ) : null}
+              <div>
+                <label className={labelClass}>사용 가능 횟수 (비우면 무제한)</label>
+                <input
+                  type="number"
+                  value={form.maxUses}
+                  onChange={(e) => setForm({ ...form, maxUses: e.target.value })}
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>최소 결제 금액 (원, 선택)</label>
+                <input
+                  type="number"
+                  value={form.minOrderAmount}
+                  onChange={(e) => setForm({ ...form, minOrderAmount: e.target.value })}
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>만료일 (선택)</label>
+                <input
+                  type="date"
+                  value={form.expiresAt}
+                  onChange={(e) => setForm({ ...form, expiresAt: e.target.value })}
+                  className={inputClass}
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <label className={labelClass}>적용 상품 (선택 안 하면 전 상품)</label>
+                <div className="flex flex-wrap gap-2">
+                  {productSlugs.map((slug) => {
+                    const on = form.productSlugs.includes(slug)
+                    return (
+                      <button
+                        key={slug}
+                        type="button"
+                        onClick={() =>
+                          setForm({
+                            ...form,
+                            productSlugs: on
+                              ? form.productSlugs.filter((s) => s !== slug)
+                              : [...form.productSlugs, slug],
+                          })
+                        }
+                        className={`border px-3 py-2 text-xs font-semibold transition ${
+                          on
+                            ? 'border-zinc-900 bg-zinc-900 text-white'
+                            : 'border-zinc-300 text-zinc-700 hover:border-zinc-500'
+                        }`}
+                      >
+                        {PRODUCT_LABEL[slug] ?? slug}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+              <div className="sm:col-span-2">
+                <label className={labelClass}>메모 (선택)</label>
+                <input
+                  value={form.description}
+                  onChange={(e) => setForm({ ...form, description: e.target.value })}
+                  className={inputClass}
+                />
+              </div>
+            </div>
+            <Button className="mt-5" onClick={create} disabled={saving}>
+              {saving ? '등록 중…' : '할인코드 등록'}
+            </Button>
+          </section>
+
+          <h2 className="mb-3 text-base font-bold text-zinc-900">등록된 코드</h2>
+          {loading ? (
+            <p className="text-sm text-zinc-500">불러오는 중…</p>
+          ) : items.length === 0 ? (
+            <p className="text-sm text-zinc-500">등록된 할인코드가 없습니다.</p>
+          ) : (
+            <div className="space-y-3">
+              {items.map((code) => (
+                <div key={code.id} className="border border-zinc-200 bg-white p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="font-mono text-sm font-bold text-zinc-900">{code.code}</p>
+                      <p className="mt-1 text-sm text-zinc-700">
+                        {code.display_name} · {describe(code)}
+                      </p>
+                      <p className="mt-1 text-xs text-zinc-500">
+                        {code.product_slugs
+                          ? code.product_slugs.map((s) => PRODUCT_LABEL[s] ?? s).join(', ')
+                          : '전 상품'}
+                        {' · '}
+                        사용 {code.usage.total}
+                        {code.max_uses ? ` / ${code.max_uses}` : ' (무제한)'}
+                        {code.usage.confirmed > 0 ? ` · 결제완료 ${code.usage.confirmed}` : ''}
+                        {code.min_order_amount > 0 ? ` · ${krw(code.min_order_amount)} 이상` : ''}
+                        {code.expires_at ? ` · ~${code.expires_at.slice(0, 10)}` : ''}
+                      </p>
+                      {code.description ? (
+                        <p className="mt-1 text-xs text-zinc-500">{code.description}</p>
+                      ) : null}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`px-2.5 py-1 text-xs font-semibold ${
+                          code.is_active ? 'bg-emerald-50 text-emerald-700' : 'bg-zinc-100 text-zinc-500'
+                        }`}
+                      >
+                        {code.is_active ? '사용 중' : '중지'}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => toggle(code)}
+                        className="border border-zinc-300 bg-white px-3 py-1.5 text-xs text-zinc-700 hover:border-zinc-500"
+                      >
+                        {code.is_active ? '중지' : '재개'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -16,7 +16,7 @@ import { toast } from 'sonner'
 import Papa from 'papaparse';
 import { Tabs as UITabs, TabsList as UITabsList, TabsTrigger as UITabsTrigger, TabsContent as UITabsContent } from '@/components/ui/tabs';
 import { SEOSettingsManager } from '@/components/dashboard/SEOSettingsManager';
-import { AlertTriangle, Users, UserCheck, FileText, Link, Receipt, Scale, UserPlus, BriefcaseBusiness, CreditCard } from 'lucide-react'
+import { AlertTriangle, Users, UserCheck, FileText, Link, Receipt, Scale, UserPlus, BriefcaseBusiness, CreditCard, Ticket } from 'lucide-react'
 import { ClaimRequestModal } from '@/components/proposals/ClaimRequestModal'
 import { DirectLinkModal } from '@/components/proposals/DirectLinkModal'
 
@@ -849,6 +849,9 @@ export default function AdminPage() {
               <TabsTrigger value="training-orders">
                 결제 주문
               </TabsTrigger>
+              <TabsTrigger value="discount-codes">
+                할인코드
+              </TabsTrigger>
               <TabsTrigger value="quotes">
                 견적서
               </TabsTrigger>
@@ -1298,6 +1301,36 @@ export default function AdminPage() {
                     >
                       <CreditCard className="w-4 h-4" />
                       결제 주문 관리로 이동
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            </TabsContent>
+
+            <TabsContent value="discount-codes">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Ticket className="w-5 h-5" />
+                    할인코드
+                  </CardTitle>
+                  <p className="text-sm text-zinc-600">
+                    결제 페이지에서 쓸 할인코드를 등록하고 사용 현황을 확인합니다
+                  </p>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-center py-12">
+                    <Ticket className="w-16 h-16 text-zinc-400 mx-auto mb-4" />
+                    <h3 className="text-lg font-medium text-zinc-900 mb-2">할인코드</h3>
+                    <p className="text-zinc-600 mb-6">
+                      퍼센트·금액 할인코드를 만들고 사용 횟수를 제한할 수 있습니다.
+                    </p>
+                    <Button
+                      onClick={() => router.push('/admin/discount-codes')}
+                      className="flex items-center gap-2"
+                    >
+                      <Ticket className="w-4 h-4" />
+                      할인코드 관리로 이동
                     </Button>
                   </div>
                 </CardContent>

--- a/src/app/api/admin/discount-codes/route.ts
+++ b/src/app/api/admin/discount-codes/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { assertAdminFromRequest } from '@/lib/admin-auth'
+import { normalizeCode } from '@/lib/discount'
+import { TRAINING_PRODUCT_SLUG } from '@/lib/training-package'
+
+// 할인코드 등록·조회·수정 (관리자).
+const ALLOWED_PRODUCT_SLUGS = [TRAINING_PRODUCT_SLUG, 'audition-fee']
+
+function getServiceRole() {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await assertAdminFromRequest(request, 'discount-codes')
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error, detail: auth.detail }, { status: auth.status })
+  }
+
+  const svc = getServiceRole()
+  const { data: codes, error } = await svc
+    .from('training_discount_codes')
+    .select('*')
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('[admin/discount-codes] list failed:', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  // 사용 횟수는 사용 이력 행 수로 센다 (코드 테이블에 카운터를 두지 않는다).
+  const { data: redemptions } = await svc
+    .from('training_discount_redemptions')
+    .select('code_id, customer_email, discount_amount, confirmed_at, created_at')
+
+  const usage = new Map<string, { total: number; confirmed: number; rows: unknown[] }>()
+  for (const row of redemptions ?? []) {
+    const key = row.code_id as string
+    if (!usage.has(key)) usage.set(key, { total: 0, confirmed: 0, rows: [] })
+    const entry = usage.get(key)!
+    entry.total += 1
+    if (row.confirmed_at) entry.confirmed += 1
+    entry.rows.push(row)
+  }
+
+  return NextResponse.json({
+    items: (codes ?? []).map((code) => ({
+      ...code,
+      usage: usage.get(code.id as string) ?? { total: 0, confirmed: 0, rows: [] },
+    })),
+    productSlugs: ALLOWED_PRODUCT_SLUGS,
+  })
+}
+
+type CreateBody = {
+  code?: string
+  displayName?: string
+  description?: string
+  discountType?: 'percentage' | 'fixed_amount'
+  discountValue?: number
+  maxDiscountAmount?: number | null
+  minOrderAmount?: number
+  maxUses?: number | null
+  productSlugs?: string[] | null
+  expiresAt?: string | null
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await assertAdminFromRequest(request, 'discount-codes')
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error, detail: auth.detail }, { status: auth.status })
+  }
+
+  try {
+    const body = (await request.json()) as CreateBody
+    const code = normalizeCode(body.code ?? '')
+    const displayName = (body.displayName ?? '').trim()
+    const discountType = body.discountType
+    const discountValue = Number(body.discountValue)
+
+    if (!/^[A-Z0-9_-]{4,64}$/.test(code)) {
+      return NextResponse.json(
+        { error: '코드는 영문 대문자·숫자·하이픈·밑줄 4~64자로 입력해 주세요.' },
+        { status: 400 },
+      )
+    }
+    if (!displayName) {
+      return NextResponse.json({ error: '표시 이름을 입력해 주세요.' }, { status: 400 })
+    }
+    if (discountType !== 'percentage' && discountType !== 'fixed_amount') {
+      return NextResponse.json({ error: '할인 방식을 선택해 주세요.' }, { status: 400 })
+    }
+    if (!Number.isFinite(discountValue) || discountValue <= 0) {
+      return NextResponse.json({ error: '할인 값을 확인해 주세요.' }, { status: 400 })
+    }
+    if (discountType === 'percentage' && discountValue > 100) {
+      return NextResponse.json({ error: '퍼센트 할인은 100을 넘을 수 없습니다.' }, { status: 400 })
+    }
+
+    const slugs = Array.isArray(body.productSlugs) ? body.productSlugs.filter(Boolean) : null
+    if (slugs && slugs.some((slug) => !ALLOWED_PRODUCT_SLUGS.includes(slug))) {
+      return NextResponse.json({ error: '알 수 없는 상품이 포함되어 있습니다.' }, { status: 400 })
+    }
+
+    const svc = getServiceRole()
+    const { data, error } = await svc
+      .from('training_discount_codes')
+      .insert({
+        code,
+        display_name: displayName,
+        description: (body.description ?? '').trim() || null,
+        discount_type: discountType,
+        discount_value: Math.floor(discountValue),
+        max_discount_amount: body.maxDiscountAmount ? Math.floor(body.maxDiscountAmount) : null,
+        min_order_amount: body.minOrderAmount ? Math.floor(body.minOrderAmount) : 0,
+        max_uses: body.maxUses ? Math.floor(body.maxUses) : null,
+        product_slugs: slugs && slugs.length > 0 ? slugs : null,
+        expires_at: body.expiresAt || null,
+      })
+      .select('*')
+      .single()
+
+    if (error) {
+      const duplicate = error.code === '23505'
+      return NextResponse.json(
+        { error: duplicate ? '이미 존재하는 코드입니다.' : error.message },
+        { status: duplicate ? 409 : 500 },
+      )
+    }
+
+    return NextResponse.json({ success: true, item: data })
+  } catch (error) {
+    console.error('[admin/discount-codes] create failed:', error)
+    return NextResponse.json({ error: '등록 중 오류가 발생했습니다.' }, { status: 500 })
+  }
+}
+
+// 활성/비활성 전환.
+export async function PATCH(request: NextRequest) {
+  const auth = await assertAdminFromRequest(request, 'discount-codes')
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error, detail: auth.detail }, { status: auth.status })
+  }
+
+  try {
+    const { id, isActive } = (await request.json()) as { id?: string; isActive?: boolean }
+    if (!id || typeof isActive !== 'boolean') {
+      return NextResponse.json({ error: '요청이 올바르지 않습니다.' }, { status: 400 })
+    }
+
+    const svc = getServiceRole()
+    const { error } = await svc
+      .from('training_discount_codes')
+      .update({ is_active: isActive, updated_at: new Date().toISOString() })
+      .eq('id', id)
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    return NextResponse.json({ success: true })
+  } catch {
+    return NextResponse.json({ error: '변경 중 오류가 발생했습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/training-orders/refund/route.ts
+++ b/src/app/api/admin/training-orders/refund/route.ts
@@ -164,7 +164,7 @@ export async function POST(request: NextRequest) {
 
     const { data: order } = await svc
       .from('training_orders')
-      .select('id, order_no, total_amount, visa_application_id')
+      .select('id, order_no, total_amount, visa_application_id, discount_code')
       .eq('id', payment.order_id)
       .maybeSingle()
 
@@ -184,6 +184,11 @@ export async function POST(request: NextRequest) {
         updated_at: refundedAt,
       })
       .eq('id', payment.order_id)
+
+    // 전액 환불이면 할인 슬롯을 돌려준다. 안 그러면 1회용 코드가 환불 후에도 소진된 채 남는다.
+    if (order?.discount_code && newPaidAmount <= 0) {
+      await svc.from('training_discount_redemptions').delete().eq('order_id', order.id)
+    }
 
     // 전액 환불로 주문에 남은 결제가 없어졌을 때만 케이스에 알린다.
     // 부분환불은 여전히 "결제된 상태"라 케이스를 환불로 뒤집으면 오히려 틀린다.

--- a/src/app/api/training/checkout/route.ts
+++ b/src/app/api/training/checkout/route.ts
@@ -3,6 +3,7 @@ import { randomBytes, randomUUID } from 'node:crypto'
 import { createClient } from '@supabase/supabase-js'
 import { foreignQuote } from '@/lib/paypal-fx'
 import { verifyVisaPaymentRef } from '@/lib/visa-payment-ref'
+import { evaluateDiscount } from '@/lib/discount'
 import {
   TRAINING_PRODUCT_SLUG,
   buildDueDates,
@@ -21,6 +22,8 @@ type Body = {
   productSlug?: string
   // deetz 비자 케이스에서 발급한 결제 링크 토큰. 있으면 주문을 그 케이스에 연결한다.
   ref?: string
+  // 할인코드. 금액은 서버가 다시 계산하며 클라이언트가 보낸 할인액은 쓰지 않는다.
+  discountCode?: string
   name?: string
   email?: string
   phone?: string
@@ -92,6 +95,35 @@ export async function POST(request: NextRequest) {
     }
     const plan = planRow as unknown as TrainingPlan
 
+    // 할인 적용. 코드가 유효하지 않으면 결제를 막고 이유를 알린다
+    // (조용히 정가로 진행하면 사용자는 할인이 먹은 줄 알고 결제한다).
+    let discountAmount = 0
+    let discountCode: string | null = null
+    if ((body.discountCode ?? '').trim()) {
+      const evaluated = await evaluateDiscount(supabase, {
+        code: body.discountCode!,
+        productSlug: requestedSlug,
+        amount: plan.total_amount,
+        email,
+      })
+      if (!evaluated.ok) {
+        return NextResponse.json({ success: false, error: evaluated.error }, { status: 400 })
+      }
+      discountAmount = evaluated.discountAmount
+      discountCode = evaluated.code.code
+    }
+
+    const totalAmount = plan.total_amount - discountAmount
+    if (totalAmount <= 0) {
+      return NextResponse.json(
+        { success: false, error: '할인 후 결제 금액이 0원이라 결제를 진행할 수 없습니다.' },
+        { status: 400 },
+      )
+    }
+    // 회차별 금액은 할인 후 총액을 나눠 담고, 나머지 원은 1회차에 붙인다.
+    const perCharge = Math.floor(totalAmount / plan.installment_months)
+    const firstCharge = totalAmount - perCharge * (plan.installment_months - 1)
+
     const now = new Date()
     const orderNo = buildOrderNo(now, randomBytes(3).toString('hex'))
     const dueDates = buildDueDates(now, plan.installment_months)
@@ -110,7 +142,10 @@ export async function POST(request: NextRequest) {
         visa_application_id: visaApplicationId,
         pg_provider: 'toss',
         currency: plan.currency,
-        total_amount: plan.total_amount,
+        total_amount: totalAmount,
+        original_amount: plan.total_amount,
+        discount_code: discountCode,
+        discount_amount: discountAmount,
         installment_months: plan.installment_months,
         status: 'pending',
         memo: (body.memo ?? '').trim() || null,
@@ -130,7 +165,7 @@ export async function POST(request: NextRequest) {
       order_id: order.id,
       sequence: index + 1,
       due_date: due,
-      amount: plan.amount_per_charge,
+      amount: index === 0 ? firstCharge : perCharge,
       currency: plan.currency,
       status: 'pending',
       pg_provider: index === 0 ? 'toss' : null,
@@ -144,12 +179,38 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: '결제 정보 생성에 실패했습니다.' }, { status: 500 })
     }
 
+    // 할인 슬롯 확보. 동시 요청이 한도를 넘기지 못하도록 DB 함수 안에서 원자적으로 처리한다.
+    // 같은 이메일이 이미 슬롯을 갖고 있으면 그 슬롯을 재사용한다(결제 중단 후 재시도 허용).
+    if (discountCode) {
+      const { error: reserveError } = await supabase.rpc('reserve_training_discount', {
+        p_code: discountCode,
+        p_email: email,
+        p_order_id: order.id,
+        p_discount_amount: discountAmount,
+      })
+      if (reserveError) {
+        await supabase.from('training_order_payments').delete().eq('order_id', order.id)
+        await supabase.from('training_orders').delete().eq('id', order.id)
+        const exhausted = String(reserveError.message ?? '').includes('DISCOUNT_EXHAUSTED')
+        return NextResponse.json(
+          {
+            success: false,
+            error: exhausted ? '이미 모두 사용된 할인코드입니다.' : '할인코드를 적용하지 못했습니다.',
+          },
+          { status: 400 },
+        )
+      }
+    }
+
     return NextResponse.json({
       success: true,
       orderNo: order.order_no,
       pgOrderId: `${order.order_no}-1`,
-      amount: plan.amount_per_charge,
-      totalAmount: plan.total_amount,
+      amount: firstCharge,
+      totalAmount,
+      originalAmount: plan.total_amount,
+      discountCode,
+      discountAmount,
       installmentMonths: plan.installment_months,
       orderName:
         plan.installment_months > 1
@@ -157,7 +218,7 @@ export async function POST(request: NextRequest) {
           : `${product.title} (${plan.label})`,
       customerKey: order.billing_customer_key,
       // PayPal은 원화를 지원하지 않아 외화로 청구된다. 사용자에게 미리 보여줄 견적.
-      paypalQuote: foreignQuote(plan.amount_per_charge),
+      paypalQuote: foreignQuote(firstCharge),
     })
   } catch (error) {
     console.error('[training/checkout] unexpected error:', error)

--- a/src/app/api/training/confirm/route.ts
+++ b/src/app/api/training/confirm/route.ts
@@ -98,7 +98,7 @@ export async function POST(request: NextRequest) {
     const { data: order } = await supabase
       .from('training_orders')
       .select(
-        'id, order_no, total_amount, installment_months, customer_name, customer_email, visa_application_id',
+        'id, order_no, total_amount, installment_months, customer_name, customer_email, visa_application_id, discount_code',
       )
       .eq('id', paymentRow.order_id)
       .maybeSingle()
@@ -120,6 +120,14 @@ export async function POST(request: NextRequest) {
         updated_at: paidAt,
       })
       .eq('id', paymentRow.order_id)
+
+    // 할인코드를 쓴 주문이면 사용 이력을 확정 처리한다(예약 → 확정).
+    if (order?.discount_code) {
+      await supabase
+        .from('training_discount_redemptions')
+        .update({ confirmed_at: paidAt, updated_at: paidAt })
+        .eq('order_id', paymentRow.order_id)
+    }
 
     // deetz 케이스에서 발급한 링크로 결제한 건이면 그쪽 케이스에도 결제 완료를 반영한다.
     // 실패해도 결제는 이미 승인됐으므로 응답을 막지 않는다.

--- a/src/app/api/training/discount/validate/route.ts
+++ b/src/app/api/training/discount/validate/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { describeDiscount, evaluateDiscount } from '@/lib/discount'
+import { TRAINING_PRODUCT_SLUG } from '@/lib/training-package'
+
+// 결제 전 할인코드 미리보기.
+// 여기서는 슬롯을 잡지 않는다. 실제 확보는 결제 생성(checkout)에서 한다.
+export const dynamic = 'force-dynamic'
+
+const ALLOWED_PRODUCT_SLUGS = new Set([TRAINING_PRODUCT_SLUG, 'audition-fee'])
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as {
+      code?: string
+      productSlug?: string
+      planCode?: string
+      email?: string
+    }
+
+    const rawCode = (body.code ?? '').trim()
+    if (!rawCode || rawCode.length > 64) {
+      return NextResponse.json({ success: false, error: '할인코드를 입력해 주세요.' }, { status: 400 })
+    }
+
+    const productSlug = (body.productSlug ?? '').trim() || TRAINING_PRODUCT_SLUG
+    if (!ALLOWED_PRODUCT_SLUGS.has(productSlug)) {
+      return NextResponse.json({ success: false, error: '상품을 찾을 수 없습니다.' }, { status: 404 })
+    }
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    )
+
+    // 금액은 요청값이 아니라 DB의 요금제에서 가져온다.
+    const { data: product } = await supabase
+      .from('training_products')
+      .select('id')
+      .eq('slug', productSlug)
+      .eq('is_active', true)
+      .maybeSingle()
+
+    if (!product) {
+      return NextResponse.json({ success: false, error: '상품을 찾을 수 없습니다.' }, { status: 404 })
+    }
+
+    const planQuery = supabase
+      .from('training_price_plans')
+      .select('code, total_amount')
+      .eq('product_id', product.id)
+      .eq('is_active', true)
+
+    const { data: plan } = (body.planCode ?? '').trim()
+      ? await planQuery.eq('code', (body.planCode ?? '').trim()).maybeSingle()
+      : await planQuery.order('sort_order', { ascending: true }).limit(1).maybeSingle()
+
+    if (!plan) {
+      return NextResponse.json({ success: false, error: '결제 방식을 선택해 주세요.' }, { status: 400 })
+    }
+
+    const amount = plan.total_amount as number
+    const result = await evaluateDiscount(supabase, {
+      code: rawCode,
+      productSlug,
+      amount,
+      email: body.email,
+    })
+
+    if (!result.ok) {
+      return NextResponse.json({ success: false, error: result.error }, { status: 200 })
+    }
+
+    return NextResponse.json({
+      success: true,
+      code: result.code.code,
+      label: result.code.display_name,
+      summary: describeDiscount(result.code),
+      originalAmount: amount,
+      discountAmount: result.discountAmount,
+      finalAmount: result.finalAmount,
+    })
+  } catch (error) {
+    console.error('[training/discount/validate] error:', error)
+    return NextResponse.json({ success: false, error: '확인 중 오류가 발생했습니다.' }, { status: 500 })
+  }
+}

--- a/src/app/api/training/paypal/capture-order/route.ts
+++ b/src/app/api/training/paypal/capture-order/route.ts
@@ -99,7 +99,7 @@ export async function POST(request: NextRequest) {
 
     const { data: order } = await supabase
       .from('training_orders')
-      .select('id, order_no, total_amount, installment_months, visa_application_id')
+      .select('id, order_no, total_amount, installment_months, visa_application_id, discount_code')
       .eq('id', paymentRow.order_id)
       .maybeSingle()
 
@@ -121,6 +121,14 @@ export async function POST(request: NextRequest) {
         updated_at: paidAt,
       })
       .eq('id', paymentRow.order_id)
+
+    // 할인코드를 쓴 주문이면 사용 이력을 확정 처리한다(예약 → 확정).
+    if (order?.discount_code) {
+      await supabase
+        .from('training_discount_redemptions')
+        .update({ confirmed_at: paidAt, updated_at: paidAt })
+        .eq('order_id', paymentRow.order_id)
+    }
 
     // deetz 케이스에서 발급한 링크로 결제한 건이면 그쪽 케이스에도 결제 완료를 반영한다.
     // 실패해도 결제는 이미 승인됐으므로 응답을 막지 않는다.

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { ArrowRight, Building2, Check, CreditCard, Globe, Loader2, ShieldCheck } from 'lucide-react'
 import { Header } from '@/components/layout/Header'
@@ -34,6 +34,15 @@ type CheckoutSession = {
   orderName: string
   customerKey: string
   paypalQuote: ForeignQuote | null
+}
+
+type AppliedDiscount = {
+  code: string
+  label: string
+  summary: string
+  originalAmount: number
+  discountAmount: number
+  finalAmount: number
 }
 
 type PaymentMethod = 'card' | 'transfer' | 'paypal'
@@ -99,12 +108,62 @@ export function TrainingClient({
   const [nationality, setNationality] = useState('')
   const [memo, setMemo] = useState('')
   const [agreed, setAgreed] = useState(false)
+  const [discountInput, setDiscountInput] = useState('')
+  const [discount, setDiscount] = useState<AppliedDiscount | null>(null)
+  const [discountError, setDiscountError] = useState<string | null>(null)
+  const [discountPending, setDiscountPending] = useState(false)
   const [pending, setPending] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [session, setSession] = useState<CheckoutSession | null>(null)
 
   const selected = useMemo(() => plans.find((plan) => plan.code === planCode) ?? null, [plans, planCode])
+  // 요금제가 바뀌면 기준 금액이 달라지므로 적용된 할인을 비운다(재확인하게 만든다).
+  useEffect(() => {
+    setDiscount(null)
+    setDiscountError(null)
+  }, [planCode])
   const origin = typeof window === 'undefined' ? 'https://grigoent.co.kr' : window.location.origin
+
+  // 할인코드 확인. 금액은 서버가 계산한 값만 표시한다.
+  const applyDiscount = async () => {
+    const code = discountInput.trim()
+    if (!code) return
+    setDiscountPending(true)
+    setDiscountError(null)
+    try {
+      const response = await fetch('/api/training/discount/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, productSlug, planCode, email }),
+      })
+      const data = await response.json()
+      if (!data.success) {
+        setDiscount(null)
+        setDiscountError(data.error ?? '사용할 수 없는 할인코드입니다.')
+        return
+      }
+      setDiscount({
+        code: data.code,
+        label: data.label,
+        summary: data.summary,
+        originalAmount: data.originalAmount,
+        discountAmount: data.discountAmount,
+        finalAmount: data.finalAmount,
+      })
+      setSession(null)
+    } catch {
+      setDiscountError('확인 중 오류가 발생했습니다.')
+    } finally {
+      setDiscountPending(false)
+    }
+  }
+
+  const removeDiscount = () => {
+    setDiscount(null)
+    setDiscountInput('')
+    setDiscountError(null)
+    setSession(null)
+  }
 
   const startCheckout = async () => {
     if (!selected) {
@@ -117,7 +176,7 @@ export function TrainingClient({
       const response = await fetch('/api/training/checkout', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ planCode, productSlug, ref: paymentRef, name, email, phone, nationality, memo, agreed, preferredLang: lang }),
+        body: JSON.stringify({ planCode, productSlug, ref: paymentRef, discountCode: discount?.code, name, email, phone, nationality, memo, agreed, preferredLang: lang }),
       })
       const data = await response.json()
       if (!response.ok || !data.success) {
@@ -271,11 +330,69 @@ export function TrainingClient({
                   <span className="font-semibold text-zinc-950">{planLabel(selected, lang)}</span>
                   <span className="text-zinc-600">{describePlan(selected, lang)}</span>
                   <span className="text-zinc-600">
-                    {t.planTotal} {formatKrw(selected.total_amount, lang)}
+                    {t.planTotal}{' '}
+                    {discount ? (
+                      <span className="text-zinc-400 line-through">
+                        {formatKrw(discount.originalAmount, lang)}
+                      </span>
+                    ) : (
+                      formatKrw(selected.total_amount, lang)
+                    )}
                   </span>
                   <span className="font-semibold text-zinc-950">
-                    {t.planPayNow} {formatKrw(selected.amount_per_charge, lang)}
+                    {t.planPayNow}{' '}
+                    {formatKrw(discount ? discount.finalAmount : selected.amount_per_charge, lang)}
                   </span>
+                </div>
+
+                <div className="mt-5 border-t border-zinc-200 pt-4">
+                  <p className="mb-2 text-sm font-semibold text-zinc-950">{t.discountTitle}</p>
+                  {discount ? (
+                    <div className="flex flex-wrap items-center justify-between gap-3 border border-emerald-300 bg-emerald-50 px-4 py-3">
+                      <div className="text-sm text-emerald-900">
+                        <p className="font-semibold">
+                          {t.discountApplied(discount.label, formatKrw(discount.discountAmount, lang))}
+                        </p>
+                        <p className="mt-0.5 text-xs">
+                          {t.discountFinal} {formatKrw(discount.finalAmount, lang)}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={removeDiscount}
+                        className="border border-emerald-400 bg-white px-3 py-1.5 text-xs font-semibold text-emerald-800 transition hover:border-emerald-600"
+                      >
+                        {t.discountRemove}
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      <input
+                        type="text"
+                        value={discountInput}
+                        onChange={(event) => setDiscountInput(event.target.value.toUpperCase())}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') {
+                            event.preventDefault()
+                            applyDiscount()
+                          }
+                        }}
+                        placeholder={t.discountPlaceholder}
+                        className="min-h-11 flex-1 border border-zinc-300 bg-white px-3 text-sm uppercase tracking-wide text-zinc-950 outline-none transition focus:border-zinc-950"
+                      />
+                      <button
+                        type="button"
+                        onClick={applyDiscount}
+                        disabled={discountPending || !discountInput.trim()}
+                        className="min-h-11 border border-zinc-950 bg-white px-5 text-sm font-semibold text-zinc-950 transition hover:bg-zinc-950 hover:text-white disabled:cursor-not-allowed disabled:border-zinc-300 disabled:text-zinc-400 disabled:hover:bg-white"
+                      >
+                        {discountPending ? t.discountChecking : t.discountApply}
+                      </button>
+                    </div>
+                  )}
+                  {discountError ? (
+                    <p className="mt-2 text-sm text-red-600">{discountError}</p>
+                  ) : null}
                 </div>
               </div>
             ) : null}

--- a/src/lib/discount.ts
+++ b/src/lib/discount.ts
@@ -1,0 +1,127 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+// 할인코드 검증·계산.
+//
+// 금액은 언제나 서버가 DB 값으로 계산한다. 클라이언트가 보낸 할인액은 절대 쓰지 않는다.
+// 검증 API 와 결제 생성(checkout)이 같은 함수를 쓰게 해서, 미리보기 금액과 실제 청구액이
+// 갈라지지 않도록 한다.
+
+export type DiscountCode = {
+  id: string
+  code: string
+  display_name: string
+  description: string | null
+  discount_type: 'percentage' | 'fixed_amount'
+  discount_value: number
+  max_discount_amount: number | null
+  min_order_amount: number
+  max_uses: number | null
+  product_slugs: string[] | null
+  is_active: boolean
+  starts_at: string | null
+  expires_at: string | null
+}
+
+export type DiscountResult =
+  | { ok: true; code: DiscountCode; discountAmount: number; finalAmount: number }
+  | { ok: false; error: string }
+
+const MESSAGES = {
+  notFound: '사용할 수 없는 할인코드입니다.',
+  inactive: '사용할 수 없는 할인코드입니다.',
+  notStarted: '아직 사용할 수 없는 할인코드입니다.',
+  expired: '유효기간이 지난 할인코드입니다.',
+  productMismatch: '이 상품에는 사용할 수 없는 할인코드입니다.',
+  minOrder: (min: number) => `${min.toLocaleString('ko-KR')}원 이상 결제 시 사용할 수 있습니다.`,
+  exhausted: '이미 모두 사용된 할인코드입니다.',
+}
+
+// 존재하지 않는 코드와 비활성 코드의 메시지를 같게 둔다.
+// 다르면 유효한 코드를 추측해 찾아낼 수 있다.
+export function normalizeCode(raw: string): string {
+  return raw.trim().toUpperCase()
+}
+
+export function computeDiscount(code: DiscountCode, amount: number): number {
+  if (code.discount_type === 'percentage') {
+    const raw = Math.floor((amount * code.discount_value) / 100)
+    const capped = code.max_discount_amount ? Math.min(raw, code.max_discount_amount) : raw
+    return Math.min(capped, amount)
+  }
+  // 정액 할인이 결제 금액보다 크면 0원 결제가 되는데, PG 가 0원을 받지 못한다.
+  // 결제 금액 전체를 넘지 않도록 자른다.
+  return Math.min(code.discount_value, amount)
+}
+
+/**
+ * 코드를 조회해 적용 가능 여부와 할인 금액을 계산한다.
+ * 사용 슬롯 확보(예약)는 하지 않는다 — 그건 결제 생성 시점의 reserve_training_discount 가 한다.
+ */
+export async function evaluateDiscount(
+  supabase: SupabaseClient,
+  input: { code: string; productSlug: string; amount: number; email?: string },
+): Promise<DiscountResult> {
+  const normalized = normalizeCode(input.code)
+  if (!normalized) return { ok: false, error: MESSAGES.notFound }
+
+  const { data, error } = await supabase
+    .from('training_discount_codes')
+    .select('*')
+    .eq('code', normalized)
+    .maybeSingle()
+
+  if (error || !data) return { ok: false, error: MESSAGES.notFound }
+  const code = data as DiscountCode
+
+  if (!code.is_active) return { ok: false, error: MESSAGES.inactive }
+
+  const now = Date.now()
+  if (code.starts_at && new Date(code.starts_at).getTime() > now) {
+    return { ok: false, error: MESSAGES.notStarted }
+  }
+  if (code.expires_at && new Date(code.expires_at).getTime() < now) {
+    return { ok: false, error: MESSAGES.expired }
+  }
+  if (code.product_slugs && code.product_slugs.length > 0 && !code.product_slugs.includes(input.productSlug)) {
+    return { ok: false, error: MESSAGES.productMismatch }
+  }
+  if (input.amount < code.min_order_amount) {
+    return { ok: false, error: MESSAGES.minOrder(code.min_order_amount) }
+  }
+
+  // 남은 사용 가능 횟수. 이미 슬롯을 가진 이메일이면 재사용이므로 한도를 보지 않는다.
+  if (code.max_uses !== null) {
+    const email = (input.email ?? '').trim().toLowerCase()
+    let mine = false
+    if (email) {
+      const { data: existing } = await supabase
+        .from('training_discount_redemptions')
+        .select('id')
+        .eq('code_id', code.id)
+        .eq('customer_email', email)
+        .maybeSingle()
+      mine = Boolean(existing)
+    }
+    if (!mine) {
+      const { count } = await supabase
+        .from('training_discount_redemptions')
+        .select('id', { count: 'exact', head: true })
+        .eq('code_id', code.id)
+      if ((count ?? 0) >= code.max_uses) {
+        return { ok: false, error: MESSAGES.exhausted }
+      }
+    }
+  }
+
+  const discountAmount = computeDiscount(code, input.amount)
+  return { ok: true, code, discountAmount, finalAmount: input.amount - discountAmount }
+}
+
+export function describeDiscount(code: DiscountCode): string {
+  if (code.discount_type === 'percentage') {
+    return code.max_discount_amount
+      ? `${code.discount_value}% 할인 (최대 ${code.max_discount_amount.toLocaleString('ko-KR')}원)`
+      : `${code.discount_value}% 할인`
+  }
+  return `${code.discount_value.toLocaleString('ko-KR')}원 할인`
+}

--- a/src/lib/training-package.ts
+++ b/src/lib/training-package.ts
@@ -146,6 +146,13 @@ export const TRAINING_COPY: Record<TrainingLang, {
   methodOverseas: string
   methodOverseasDesc: string
   paypalCurrencyNotice: (foreign: string, krw: string) => string
+  discountTitle: string
+  discountPlaceholder: string
+  discountApply: string
+  discountRemove: string
+  discountChecking: string
+  discountApplied: (label: string, amount: string) => string
+  discountFinal: string
   paySubmit: (amount: string) => string
   editInfo: string
   notice: string
@@ -204,6 +211,13 @@ export const TRAINING_COPY: Record<TrainingLang, {
     methodOverseasDesc: '해외 카드 · PayPal 잔액',
     paypalCurrencyNotice: (foreign, krw) =>
       `PayPal은 원화 결제를 지원하지 않습니다. 결제 금액 ${krw}은 ${foreign}로 청구됩니다.`,
+    discountTitle: '할인코드',
+    discountPlaceholder: '할인코드를 입력하세요',
+    discountApply: '적용',
+    discountRemove: '해제',
+    discountChecking: '확인 중…',
+    discountApplied: (label, amount) => `${label} 적용 — ${amount} 할인`,
+    discountFinal: '할인 적용 후 결제 금액',
     paySubmit: (amount) => `${amount} 결제하기`,
     editInfo: '정보 수정하기',
     notice:
@@ -264,6 +278,13 @@ export const TRAINING_COPY: Record<TrainingLang, {
     methodOverseasDesc: 'International cards · PayPal balance',
     paypalCurrencyNotice: (foreign, krw) =>
       `PayPal cannot charge Korean won. Your payment of ${krw} will be billed as ${foreign}.`,
+    discountTitle: 'Discount code',
+    discountPlaceholder: 'Enter your discount code',
+    discountApply: 'Apply',
+    discountRemove: 'Remove',
+    discountChecking: 'Checking…',
+    discountApplied: (label, amount) => `${label} applied — ${amount} off`,
+    discountFinal: 'Amount after discount',
     paySubmit: (amount) => `Pay ${amount}`,
     editInfo: 'Edit my details',
     notice:
@@ -324,6 +345,13 @@ export const TRAINING_COPY: Record<TrainingLang, {
     methodOverseasDesc: '海外カード · PayPal残高',
     paypalCurrencyNotice: (foreign, krw) =>
       `PayPalはウォン建て決済に対応していません。お支払い金額${krw}は${foreign}で請求されます。`,
+    discountTitle: '割引コード',
+    discountPlaceholder: '割引コードを入力してください',
+    discountApply: '適用',
+    discountRemove: '解除',
+    discountChecking: '確認中…',
+    discountApplied: (label, amount) => `${label} 適用 — ${amount} 割引`,
+    discountFinal: '割引適用後のお支払い金額',
     paySubmit: (amount) => `${amount}を決済する`,
     editInfo: '情報を修正する',
     notice:


### PR DESCRIPTION
`/training` 과 `/audition-fee` 양쪽에서 쓰는 할인코드입니다. 퍼센트·금액 할인 모두 지원합니다.

## modoo 참고

타입 명명(`percentage` / `fixed_amount`)은 modoo `coupons.discount_type` 과 맞췄습니다.
사업부마다 같은 개념을 다르게 부르면 나중에 통합 조회가 안 됩니다.

## 동시성·정합성

**사용 횟수를 코드 테이블 카운터로 두지 않았습니다.** 사용 이력 행 수로 셉니다 — 카운터는 반드시 어긋납니다.

**슬롯 확보는 DB 함수(`reserve_training_discount`) 안에서 원자적으로** 합니다.
애플리케이션에서 "센 다음 넣기"로 하면 동시 요청이 한도를 넘길 수 있습니다.

**`(code_id, customer_email)` 유니크**가 핵심입니다.
같은 사람이 결제를 중단했다가 다시 시도하면 자기 슬롯을 재사용하고, 다른 사람이 한도를 넘겨 쓰려 하면 막힙니다.
이게 없으면 1회용 코드는 결제를 한 번 중단하는 순간 영영 못 쓰게 됩니다.

## 금액 신뢰 경계

금액은 언제나 서버가 DB 값으로 계산합니다. 클라이언트가 보낸 할인액은 쓰지 않습니다.
검증 API 와 checkout 이 같은 함수(`evaluateDiscount`)를 써서, 미리보기 금액과 실제 청구액이 갈라지지 않습니다.

**코드가 유효하지 않으면 결제를 막습니다.** 조용히 정가로 진행하면 사용자는 할인이 먹은 줄 알고 결제합니다.

## 환불

전액 환불 시 할인 슬롯을 반환합니다. 안 그러면 1회용 코드가 환불 후에도 소진된 채 남습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)