### PR TITLE
fix(payments): 할인코드 입력칸을 기본으로 접는다

### DIFF
--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -112,6 +112,8 @@ export function TrainingClient({
   const [discount, setDiscount] = useState<AppliedDiscount | null>(null)
   const [discountError, setDiscountError] = useState<string | null>(null)
   const [discountPending, setDiscountPending] = useState(false)
+  // 할인코드가 있는 사람은 소수라 기본은 접어두고, 링크를 눌러야 입력칸이 열린다.
+  const [discountOpen, setDiscountOpen] = useState(false)
   const [pending, setPending] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [session, setSession] = useState<CheckoutSession | null>(null)
@@ -162,6 +164,7 @@ export function TrainingClient({
     setDiscount(null)
     setDiscountInput('')
     setDiscountError(null)
+    setDiscountOpen(false)
     setSession(null)
   }
 
@@ -346,7 +349,9 @@ export function TrainingClient({
                 </div>
 
                 <div className="mt-5 border-t border-zinc-200 pt-4">
-                  <p className="mb-2 text-sm font-semibold text-zinc-950">{t.discountTitle}</p>
+                  {discount || discountOpen ? (
+                    <p className="mb-2 text-sm font-semibold text-zinc-950">{t.discountTitle}</p>
+                  ) : null}
                   {discount ? (
                     <div className="flex flex-wrap items-center justify-between gap-3 border border-emerald-300 bg-emerald-50 px-4 py-3">
                       <div className="text-sm text-emerald-900">
@@ -365,10 +370,19 @@ export function TrainingClient({
                         {t.discountRemove}
                       </button>
                     </div>
+                  ) : !discountOpen ? (
+                    <button
+                      type="button"
+                      onClick={() => setDiscountOpen(true)}
+                      className="text-xs text-zinc-500 underline underline-offset-4 transition hover:text-zinc-900"
+                    >
+                      {t.discountToggle}
+                    </button>
                   ) : (
                     <div className="flex flex-wrap gap-2">
                       <input
                         type="text"
+                        autoFocus
                         value={discountInput}
                         onChange={(event) => setDiscountInput(event.target.value.toUpperCase())}
                         onKeyDown={(event) => {

--- a/src/lib/training-package.ts
+++ b/src/lib/training-package.ts
@@ -147,6 +147,7 @@ export const TRAINING_COPY: Record<TrainingLang, {
   methodOverseasDesc: string
   paypalCurrencyNotice: (foreign: string, krw: string) => string
   discountTitle: string
+  discountToggle: string
   discountPlaceholder: string
   discountApply: string
   discountRemove: string
@@ -212,6 +213,7 @@ export const TRAINING_COPY: Record<TrainingLang, {
     paypalCurrencyNotice: (foreign, krw) =>
       `PayPal은 원화 결제를 지원하지 않습니다. 결제 금액 ${krw}은 ${foreign}로 청구됩니다.`,
     discountTitle: '할인코드',
+    discountToggle: '할인코드가 있으신가요?',
     discountPlaceholder: '할인코드를 입력하세요',
     discountApply: '적용',
     discountRemove: '해제',
@@ -279,6 +281,7 @@ export const TRAINING_COPY: Record<TrainingLang, {
     paypalCurrencyNotice: (foreign, krw) =>
       `PayPal cannot charge Korean won. Your payment of ${krw} will be billed as ${foreign}.`,
     discountTitle: 'Discount code',
+    discountToggle: 'Have a discount code?',
     discountPlaceholder: 'Enter your discount code',
     discountApply: 'Apply',
     discountRemove: 'Remove',
@@ -346,6 +349,7 @@ export const TRAINING_COPY: Record<TrainingLang, {
     paypalCurrencyNotice: (foreign, krw) =>
       `PayPalはウォン建て決済に対応していません。お支払い金額${krw}は${foreign}で請求されます。`,
     discountTitle: '割引コード',
+    discountToggle: '割引コードをお持ちですか？',
     discountPlaceholder: '割引コードを入力してください',
     discountApply: '適用',
     discountRemove: '解除',


### PR DESCRIPTION
할인코드를 가진 사람은 소수인데 입력칸이 항상 펼쳐져 있으면, 코드가 없는 대부분의 구매자가 "내가 손해 보는 건가" 하고 결제를 멈추게 됩니다.

**변경 후**: 금액 요약 아래에 작은 회색 링크로 "할인코드가 있으신가요?" 만 보이고, 누르면 입력칸이 열립니다.

- ko / en / ja 3개 언어
- 열리면 `autoFocus` 로 바로 입력 가능
- 적용된 뒤에는 계속 보임 (접히지 않음)
- 해제하면 다시 접힘

🤖 Generated with [Claude Code](https://claude.com/claude-code)