### PR TITLE
fix(payments): 프로덕션 테스트키 승인 차단 + 결제자 이메일 전달

### DIFF
--- a/src/app/api/training/confirm/route.ts
+++ b/src/app/api/training/confirm/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
-import { tossSecretKey } from '@/lib/toss-keys'
+import { TOSS_USE_LIVE, tossSecretKey } from '@/lib/toss-keys'
 import { notifyVisaCasePayment } from '@/lib/visa-payment-ref'
 import { sendPaymentReceipt } from '@/lib/payment-receipt'
 
@@ -61,6 +61,22 @@ export async function POST(request: NextRequest) {
     const secretKey = tossSecretKey()
     if (!secretKey) {
       return NextResponse.json({ success: false, error: '결제 설정이 완료되지 않았습니다.' }, { status: 500 })
+    }
+
+    // 프로덕션에서 테스트키 승인 금지.
+    // 테스트키로 승인하면 돈은 안 움직이는데 DB 는 '결제 완료'가 되고 영수증까지 나간다.
+    // 실제로 2026-08-18 스위치 미전환 상태에서 sandbox 결제가 '완료' 처리된 사고가 있었다.
+    // 라이브 전환 전 검수가 필요하면 TOSS_ALLOW_TEST_IN_PROD=true 로 명시적으로만 연다.
+    if (
+      process.env.VERCEL_ENV === 'production' &&
+      !TOSS_USE_LIVE &&
+      process.env.TOSS_ALLOW_TEST_IN_PROD !== 'true'
+    ) {
+      console.error('[training/confirm] BLOCKED: test-key confirm attempted in production', { orderId })
+      return NextResponse.json(
+        { success: false, error: '결제 환경 설정 오류로 결제를 완료할 수 없습니다. 카드에는 청구되지 않았습니다.' },
+        { status: 503 },
+      )
     }
 
     const tossResponse = await fetch('https://api.tosspayments.com/v1/payments/confirm', {
@@ -163,7 +179,7 @@ export async function POST(request: NextRequest) {
         provider: 'toss',
         amountKrw: paidAmount,
         occurredAt: paidAt,
-        meta: { paymentKey, sequence: paymentRow.sequence, receiptUrl: tossData?.receipt?.url ?? null },
+        meta: { paymentKey, sequence: paymentRow.sequence, receiptUrl: tossData?.receipt?.url ?? null, customerEmail: order.customer_email ?? null },
       })
     }
 

--- a/src/app/api/training/paypal/capture-order/route.ts
+++ b/src/app/api/training/paypal/capture-order/route.ts
@@ -68,6 +68,19 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: true, idempotent: true, orderNo: paidOrder?.order_no ?? null })
     }
 
+    // 프로덕션에서 sandbox 승인 금지 — 돈이 안 움직이는데 '결제 완료'가 되는 것을 막는다.
+    if (
+      process.env.VERCEL_ENV === 'production' &&
+      IS_SANDBOX &&
+      process.env.PAYPAL_ALLOW_SANDBOX_IN_PROD !== 'true'
+    ) {
+      console.error('[training/paypal] BLOCKED: sandbox capture attempted in production', { pgOrderId })
+      return NextResponse.json(
+        { success: false, error: '결제 환경 설정 오류로 결제를 완료할 수 없습니다. 청구되지 않았습니다.' },
+        { status: 503 },
+      )
+    }
+
     const accessToken = await getAccessToken()
 
     // 캡처하기 전에 이 PayPal 주문이 정말 이 결제건(pgOrderId)의 것인지 확인한다.
@@ -156,7 +169,7 @@ export async function POST(request: NextRequest) {
 
     const { data: order } = await supabase
       .from('training_orders')
-      .select('id, order_no, total_amount, installment_months, visa_application_id, discount_code')
+      .select('id, order_no, total_amount, installment_months, visa_application_id, discount_code, customer_email')
       .eq('id', paymentRow.order_id)
       .maybeSingle()
 
@@ -211,7 +224,7 @@ export async function POST(request: NextRequest) {
         provider: 'paypal',
         amountKrw: paidAmount,
         occurredAt: paidAt,
-        meta: { paypalTransactionId: captureDetails?.id ?? null, sequence: paymentRow.sequence },
+        meta: { paypalTransactionId: captureDetails?.id ?? null, sequence: paymentRow.sequence, customerEmail: order.customer_email ?? null },
       })
     }
 


### PR DESCRIPTION
deetz PR과 한 세트입니다: tkaykim/dancers-bio#148

## 1. 프로덕션 테스트키 승인 차단

8/18 사고: 라이브 키가 등록돼 있는데 스위치가 꺼진 채 sandbox 결제가 '완료' 처리되고 영수증까지 나갔습니다.

이제 프로덕션에서 테스트키(토스) / sandbox(PayPal) 승인 요청은 **거부**됩니다.
사용자에게는 "청구되지 않았습니다"를 명시한 오류가 보입니다 — 돈이 안 움직였는데 완료로 기록되는 것보다 백배 낫습니다.

검수가 필요하면 `TOSS_ALLOW_TEST_IN_PROD=true` / `PAYPAL_ALLOW_SANDBOX_IN_PROD=true` 로만 열 수 있습니다.

## 2. 결제자 이메일 전달

토스/PayPal 승인 콜백 meta에 `customerEmail`을 실어, deetz가 링크 소지자가 아니라 **결제자** 기준으로 케이스를 귀속하게 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)