### PR TITLE
feat(payments): 1개월 트레이닝 비용 결제 페이지

### DIFF
--- a/src/app/api/training/checkout/route.ts
+++ b/src/app/api/training/checkout/route.ts
@@ -10,6 +10,7 @@ import {
   buildDueDates,
   buildOrderNo,
   type TrainingPlan,
+  MONTHLY_TRAINING_PRODUCT_SLUG,
 } from '@/lib/training-package'
 
 function getSupabase() {
@@ -38,6 +39,7 @@ const ALLOWED_PRODUCT_SLUGS = new Set([
   TRAINING_PRODUCT_SLUG,
   'audition-fee',
   VILLAGE_DEPOSIT_PRODUCT_SLUG,
+  MONTHLY_TRAINING_PRODUCT_SLUG,
 ])
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/

--- a/src/app/monthly-training/page.tsx
+++ b/src/app/monthly-training/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from 'next'
+import { createClient } from '@supabase/supabase-js'
+import { TrainingClient } from '@/app/training/TrainingClient'
+import { MONTHLY_TRAINING_COPY, MONTHLY_TRAINING_PRODUCT_SLUG } from '@/lib/training-package'
+import type { TrainingPlan, TrainingProduct } from '@/lib/training-package'
+
+// 1개월 트레이닝 비용 결제 페이지.
+// ⚠ 이 상품은 트레이닝 패키지(/training)를 나눠 내는 분납 상품이 아니다.
+//    비자 행정 대행이 빠진 별개 상품이며, 매달 그 달의 이용료만 받고
+//    다음 달 계속 여부는 이용자가 매달 다시 정한다.
+//    총액 합산·회차·분납·할부 표현을 화면에 노출하지 않는다 (토스페이먼츠 심사 조건).
+// 토스 카드사 심사 대상 URL(/training)과 분리된 별도 경로이며,
+// 그 화면·구성에 영향을 주지 않도록 검색엔진에서도 제외한다.
+export const dynamic = 'force-dynamic'
+
+const PRODUCT_SLUG = MONTHLY_TRAINING_PRODUCT_SLUG
+
+export const metadata: Metadata = {
+  title: '1개월 트레이닝 비용 - 그리고 엔터테인먼트',
+  description: '트레이닝 수강권, 실무 한국어 교육, 실무 투입 업무교육이 포함된 1개월 이용권 결제 페이지입니다.',
+  robots: { index: false, follow: false },
+}
+
+export default async function MonthlyTrainingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ ref?: string }>
+}) {
+  // deetz 케이스에서 발급한 결제 링크 토큰. 검증은 서버(checkout)에서만 한다.
+  const { ref } = await searchParams
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  )
+
+  const { data: productRow } = await supabase
+    .from('training_products')
+    .select('id, slug, title, subtitle, description, highlights, currency, i18n')
+    .eq('slug', PRODUCT_SLUG)
+    .eq('is_active', true)
+    .maybeSingle()
+
+  let plans: TrainingPlan[] = []
+  if (productRow) {
+    const { data: planRows } = await supabase
+      .from('training_price_plans')
+      .select('id, code, label, plan_type, installment_months, amount_per_charge, total_amount, currency, note, sort_order, i18n')
+      .eq('product_id', productRow.id)
+      .eq('is_active', true)
+      .order('sort_order', { ascending: true })
+    plans = (planRows ?? []) as unknown as TrainingPlan[]
+  }
+
+  const product = productRow
+    ? ({
+        ...productRow,
+        highlights: Array.isArray(productRow.highlights) ? (productRow.highlights as string[]) : [],
+      } as TrainingProduct)
+    : null
+
+  return (
+    <TrainingClient
+      product={product}
+      plans={plans}
+      productSlug={PRODUCT_SLUG}
+      paymentRef={ref}
+      copyOverride={MONTHLY_TRAINING_COPY}
+    />
+  )
+}

--- a/src/app/training/TrainingClient.tsx
+++ b/src/app/training/TrainingClient.tsx
@@ -25,6 +25,14 @@ import {
 } from '@/lib/training-package'
 import { cn } from '@/lib/utils'
 
+// 트레이닝 패키지 화면 하단에서 월 단위 상품으로 넘어가는 안내 문구.
+// ⚠ 금액·개월수·총액을 넣지 않는다. 넣는 순간 분납 안내로 읽힌다.
+const MONTHLY_TRAINING_LINK: Record<'ko' | 'en' | 'ja', string> = {
+  ko: '트레이닝만 월 단위로 이용하실 수도 있습니다',
+  en: 'You can also take the training on a monthly basis',
+  ja: 'トレーニングのみを月単位でご利用いただくこともできます',
+}
+
 type CheckoutSession = {
   orderNo: string
   pgOrderId: string
@@ -649,6 +657,23 @@ export function TrainingClient({
             </div>
           </div>
         </section>
+
+        {/* 트레이닝 패키지 화면에서만 노출하는 별개 상품 안내.
+            ⚠ 분납·할부 안내가 아니다. 비자 행정이 빠진 월 단위 상품이 따로 있다는 안내이며,
+               금액·총액을 여기서 노출하지 않는다 (토스페이먼츠 심사 조건). */}
+        {!productSlug ? (
+          <section className="border-t border-zinc-200 bg-white">
+            <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
+              <a
+                href="/monthly-training"
+                className="inline-flex items-center gap-2 text-sm text-zinc-600 underline underline-offset-4 transition hover:text-zinc-950"
+              >
+                {MONTHLY_TRAINING_LINK[lang]}
+                <ArrowRight className="h-4 w-4" />
+              </a>
+            </div>
+          </section>
+        ) : null}
 
         <MerchantInfoFooter lang={lang} servicePeriod={copyOverride?.[lang]?.servicePeriod} />
       </main>

--- a/src/lib/training-package.ts
+++ b/src/lib/training-package.ts
@@ -524,3 +524,76 @@ export const VILLAGE_DEPOSIT_COPY: Record<
 }
 
 export const VILLAGE_DEPOSIT_PRODUCT_SLUG = 'village-deposit'
+
+// 1개월 트레이닝 비용(/monthly-training) 전용 카피.
+// ⚠ 이 상품은 "400만원 패키지를 나눠 내는 것"이 아니라 월 단위로 판매하는 별개 상품이다.
+// 비자 행정 대행이 포함되지 않으며, 매달 그 달의 이용료만 받고 다음 달 계속 여부는 매달 정한다.
+// 따라서 총액 합산·회차·분납·할부 표현을 절대 쓰지 않는다 (토스페이먼츠 심사 조건).
+export const MONTHLY_TRAINING_COPY: Record<
+  TrainingLang,
+  {
+    process: { title: string; body: string }[]
+    servicePeriod: string
+    terms: { title: string; items: string[] }
+  }
+> = {
+  ko: {
+    process: [
+      { title: '1개월권 결제', body: '이용하실 한 달의 이용료를 결제합니다.' },
+      { title: '수업 배정', body: '결제 확인 후 수업 일정과 시작일을 개별 안내드립니다.' },
+      { title: '한 달 이용', body: '트레이닝 수강, 실무 한국어 교육, 실무 투입 업무교육을 이용하십니다.' },
+      { title: '다음 달 선택', body: '다음 달 계속하실지는 매달 다시 정하시면 됩니다.' },
+    ],
+    servicePeriod: '이용 시작일로부터 1개월',
+    terms: {
+      title: '결제 전 확인해 주세요',
+      items: [
+        '이 상품은 한 달 단위 이용권입니다. 결제하신 금액은 이용하실 한 달분이며, 다음 달 이용료가 자동으로 청구되지 않습니다.',
+        '다음 달에도 계속 이용하실지는 매달 다시 선택하시면 됩니다. 중단하시면 이후 달은 청구되지 않습니다.',
+        '트레이닝 수강권, 실무 한국어 교육, 실무 투입 업무교육이 포함됩니다.',
+        '비자 신청·서류 대행 등 행정 지원은 이 상품에 포함되지 않습니다. 해당 지원이 필요하시면 별도로 문의해 주세요.',
+        '이용 시작 전에는 전액 환불해 드립니다. 이용을 시작하신 뒤의 환불은 취소·환불 규정을 따릅니다.',
+      ],
+    },
+  },
+  en: {
+    process: [
+      { title: 'Pay for one month', body: 'Pay the fee for the month you plan to attend.' },
+      { title: 'Class assignment', body: 'Once payment is confirmed we send your schedule and start date.' },
+      { title: 'Attend for a month', body: 'Take training classes, practical Korean lessons, and on-the-job work preparation.' },
+      { title: 'Choose again', body: 'You decide each month whether to continue.' },
+    ],
+    servicePeriod: 'One month from your start date',
+    terms: {
+      title: 'Before you pay',
+      items: [
+        'This is a one-month pass. You are paying for one month only, and the next month is not charged automatically.',
+        'You decide each month whether to continue. If you stop, nothing further is charged.',
+        'It includes training classes, practical Korean lessons, and on-the-job work preparation.',
+        'Visa applications and document handling are not included in this product. Please contact us separately if you need that support.',
+        'You get a full refund before your start date. After you begin, refunds follow our cancellation and refund policy.',
+      ],
+    },
+  },
+  ja: {
+    process: [
+      { title: '1ヶ月分のお支払い', body: 'ご利用になる1ヶ月分の利用料をお支払いいただきます。' },
+      { title: 'クラスのご案内', body: '入金確認後、レッスン日程と開始日を個別にご案内します。' },
+      { title: '1ヶ月のご利用', body: 'トレーニング受講、実務韓国語教育、実務投入業務教育をご利用いただきます。' },
+      { title: '翌月のご選択', body: '翌月も続けるかどうかは毎月あらためてお選びいただけます。' },
+    ],
+    servicePeriod: 'ご利用開始日から1ヶ月',
+    terms: {
+      title: 'お支払い前にご確認ください',
+      items: [
+        'こちらは1ヶ月単位の利用券です。お支払いいただくのは1ヶ月分のみで、翌月分が自動的に請求されることはありません。',
+        '翌月も継続されるかどうかは毎月あらためてお選びいただけます。中止された場合、それ以降のご請求はありません。',
+        'トレーニング受講券、実務韓国語教育、実務投入業務教育が含まれます。',
+        'ビザ申請・書類代行などの行政サポートは本商品に含まれません。必要な場合は別途お問い合わせください。',
+        'ご利用開始前であれば全額返金いたします。ご利用開始後の返金はキャンセル・返金規定に従います。',
+      ],
+    },
+  },
+}
+
+export const MONTHLY_TRAINING_PRODUCT_SLUG = 'monthly-training'


### PR DESCRIPTION
## 무엇

트레이닝 패키지(400만원)와 **별개 상품**으로, 트레이닝만 월 단위로 이용하는 `1개월 트레이닝 비용`(월 1,400,000원) 결제 페이지를 추가합니다.

- 신규 라우트 `/monthly-training` — `audition-fee`·`village-deposit` 과 동일 패턴, `noindex`
- `MONTHLY_TRAINING_COPY` (ko/en/ja) — 진행 4단계·서비스 제공기간·결제 전 고지
- checkout 허용 슬러그에 `monthly-training` 추가
- `/training` 하단에 월 단위 상품 안내 링크 1줄

DB(상품·요금제)는 이미 등록되어 있습니다.
`training_products.slug = monthly-training` / `training_price_plans.code = onetime` (1,400,000 KRW).

## 왜 분납이 아닌가

토스페이먼츠는 **"한 상품에 대한 대금을 분할"** 하는 방식을 심사 불가로 통보했고, 그 조건으로 기존 분납 시스템을 제거(#28)한 뒤 심사가 진행됐습니다.

이 상품은 그 제약에 걸리지 않습니다.

| | 트레이닝 패키지 | 1개월 트레이닝 비용 |
|---|---|---|
| 트레이닝·실무 한국어·실무 투입 교육 | 포함 | 포함 |
| **비자 행정 대행** | 포함 | **미포함** |
| 결제 단위 | 전 과정 1회 | 이용하는 달마다 |

포함 범위가 다른 별개 상품이며, 매달 그 달의 이용료만 받고 다음 달 계속 여부는 이용자가 매달 정합니다. 중단하면 이후 달은 청구하지 않습니다.

## 심사 관련 제약을 코드에 고정했습니다

- 화면 어디에도 **총액 합산·회차·분납·할부** 표현을 노출하지 않습니다. `/training` 하단 링크에도 금액을 넣지 않았습니다.
- `/training` 은 카드사 심사 대상 URL 이라 화면 구성을 바꾸지 않고 링크 한 줄만 덧붙였습니다.
- 신규 페이지는 `robots: noindex` 입니다.
- 위 제약의 이유를 각 파일 주석으로 남겼습니다.

## 검증

- `npm run build` 통과, `/monthly-training` 라우트 등록 확인 (ƒ Dynamic, 240 kB)
- 실제 결제 승인은 미실행 — 머지 후 소액 실결제로 확인이 필요합니다

## 남은 확인

해외결제 MID(`gtrainlt7y`)가 심사 중이라, 상품 구조 변경 사실을 토스에 한 줄 공유해 두는 편이 안전합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)