### PR TITLE
feat(payments): 결제 승인·취소 점검용 소액 결제 경로

### DIFF
--- a/src/app/api/training/checkout/route.ts
+++ b/src/app/api/training/checkout/route.ts
@@ -11,6 +11,7 @@ import {
   buildOrderNo,
   type TrainingPlan,
   MONTHLY_TRAINING_PRODUCT_SLUG,
+  PAYMENT_TEST_PRODUCT_SLUG,
 } from '@/lib/training-package'
 
 function getSupabase() {
@@ -40,6 +41,8 @@ const ALLOWED_PRODUCT_SLUGS = new Set([
   'audition-fee',
   VILLAGE_DEPOSIT_PRODUCT_SLUG,
   MONTHLY_TRAINING_PRODUCT_SLUG,
+  // 결제 수단 점검용(내부). training_products.is_active 로 즉시 차단할 수 있다.
+  PAYMENT_TEST_PRODUCT_SLUG,
 ])
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/

--- a/src/app/payment-test/page.tsx
+++ b/src/app/payment-test/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next'
+import { createClient } from '@supabase/supabase-js'
+import { TrainingClient } from '@/app/training/TrainingClient'
+import { PAYMENT_TEST_COPY, PAYMENT_TEST_PRODUCT_SLUG } from '@/lib/training-package'
+import type { TrainingPlan, TrainingProduct } from '@/lib/training-package'
+
+// 결제 수단 점검(내부용) 페이지.
+//
+// 실제 판매 상품은 400만원·140만원이라 소액 테스트가 불가능하다.
+// 승인·취소가 실제로 도는지만 100원 / 1,000원으로 확인하기 위한 경로다.
+//
+// ⚠ 판매 페이지가 아니다. 어디에서도 링크하지 않고 sitemap 에도 넣지 않으며 noindex 로 둔다.
+// ⚠ 즉시 차단: update training_products set is_active = false where slug = 'payment-test';
+//    (페이지는 빈 화면으로, checkout API 는 404 로 함께 막힌다 — 코드 배포 없이 끌 수 있다.)
+export const dynamic = 'force-dynamic'
+
+const PRODUCT_SLUG = PAYMENT_TEST_PRODUCT_SLUG
+
+export const metadata: Metadata = {
+  title: '결제 수단 점검 - 그리고 엔터테인먼트',
+  description: '결제 승인과 취소가 정상 동작하는지 확인하기 위한 내부 점검용 페이지입니다.',
+  robots: { index: false, follow: false },
+}
+
+export default async function PaymentTestPage() {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  )
+
+  const { data: productRow } = await supabase
+    .from('training_products')
+    .select('id, slug, title, subtitle, description, highlights, currency, i18n')
+    .eq('slug', PRODUCT_SLUG)
+    .eq('is_active', true)
+    .maybeSingle()
+
+  let plans: TrainingPlan[] = []
+  if (productRow) {
+    const { data: planRows } = await supabase
+      .from('training_price_plans')
+      .select('id, code, label, plan_type, installment_months, amount_per_charge, total_amount, currency, note, sort_order, i18n')
+      .eq('product_id', productRow.id)
+      .eq('is_active', true)
+      .order('sort_order', { ascending: true })
+    plans = (planRows ?? []) as unknown as TrainingPlan[]
+  }
+
+  const product = productRow
+    ? ({
+        ...productRow,
+        highlights: Array.isArray(productRow.highlights) ? (productRow.highlights as string[]) : [],
+      } as TrainingProduct)
+    : null
+
+  return (
+    <TrainingClient
+      product={product}
+      plans={plans}
+      productSlug={PRODUCT_SLUG}
+      copyOverride={PAYMENT_TEST_COPY}
+    />
+  )
+}

--- a/src/lib/training-package.ts
+++ b/src/lib/training-package.ts
@@ -597,3 +597,79 @@ export const MONTHLY_TRAINING_COPY: Record<
 }
 
 export const MONTHLY_TRAINING_PRODUCT_SLUG = 'monthly-training'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 결제 수단 점검(내부용) — 실결제 승인·취소가 실제로 도는지 최소 금액으로 확인한다.
+//
+// ⚠ 판매 상품이 아니다. 어디에서도 링크하지 않고 검색엔진에서도 제외한다.
+//    실제 상품(400만원·140만원)은 금액이 커서 소액 테스트가 불가능하기 때문에,
+//    "승인이 되는가 / 취소가 되는가"만 100원·1,000원으로 확인하기 위한 경로다.
+//
+// 끄는 방법(운영 중 즉시 차단):
+//   update training_products set is_active = false where slug = 'payment-test';
+//   → 페이지는 "판매 중인 상품이 없습니다"로 바뀌고 checkout API 도 404 로 막힌다.
+export const PAYMENT_TEST_PRODUCT_SLUG = 'payment-test'
+
+export const PAYMENT_TEST_COPY: Record<
+  TrainingLang,
+  {
+    process: { title: string; body: string }[]
+    servicePeriod: string
+    terms: { title: string; items: string[] }
+  }
+> = {
+  ko: {
+    process: [
+      { title: '금액 선택', body: '100원 또는 1,000원 중 하나를 선택합니다.' },
+      { title: '결제', body: '카드(토스페이먼츠) 또는 PayPal 로 실제 결제를 진행합니다.' },
+      { title: '승인 확인', body: 'PG 상점관리자와 관리자 화면에서 승인 내역과 금액을 대조합니다.' },
+      { title: '즉시 취소', body: '/admin/training-orders 에서 전액 환불하고 취소 반영까지 확인합니다.' },
+    ],
+    servicePeriod: '해당 없음 (결제 수단 점검용)',
+    terms: {
+      title: '이 페이지에 대하여',
+      items: [
+        '이 페이지는 판매 페이지가 아니라 결제 수단이 정상 동작하는지 확인하기 위한 내부 점검용 경로입니다.',
+        '결제하시면 실제로 대금이 청구됩니다. 점검이 끝나면 바로 전액 취소합니다.',
+        '어떤 상품이나 서비스도 제공되지 않습니다.',
+        '고객님께서 이 페이지에 잘못 들어오셨다면 결제하지 마시고 창을 닫아 주세요.',
+      ],
+    },
+  },
+  en: {
+    process: [
+      { title: 'Pick an amount', body: 'Choose either KRW 100 or KRW 1,000.' },
+      { title: 'Pay', body: 'Run a real payment by card (Toss Payments) or PayPal.' },
+      { title: 'Check the approval', body: 'Match the approval and amount in the PG console and the admin screen.' },
+      { title: 'Cancel right away', body: 'Refund in full from /admin/training-orders and confirm the cancellation.' },
+    ],
+    servicePeriod: 'Not applicable (payment smoke test)',
+    terms: {
+      title: 'About this page',
+      items: [
+        'This is not a sales page. It exists only to verify that our payment methods work.',
+        'A payment made here is a real charge. It is refunded in full as soon as the check is done.',
+        'No product or service is provided.',
+        'If you reached this page by mistake, please close it without paying.',
+      ],
+    },
+  },
+  ja: {
+    process: [
+      { title: '金額の選択', body: '100ウォンまたは1,000ウォンを選びます。' },
+      { title: '決済', body: 'カード（トスペイメンツ）または PayPal で実際に決済します。' },
+      { title: '承認の確認', body: 'PG 管理画面と管理者画面で承認内容と金額を照合します。' },
+      { title: '即時キャンセル', body: '/admin/training-orders から全額返金し、取消の反映まで確認します。' },
+    ],
+    servicePeriod: '該当なし（決済手段の点検用）',
+    terms: {
+      title: 'このページについて',
+      items: [
+        'こちらは販売ページではなく、決済手段が正常に動作するかを確認するための内部点検用ページです。',
+        '決済すると実際に請求が発生します。点検が終わり次第、全額を取り消します。',
+        '商品やサービスの提供はありません。',
+        '誤ってこのページに入られた場合は、決済せずに閉じてください。',
+      ],
+    },
+  },
+}


### PR DESCRIPTION
## 왜

실제 판매 상품은 400만원(`/training`)·140만원(`/monthly-training`)이라 소액 테스트가 불가능하다.
그래서 8/19 토스 라이브 전환 이후 **승인 성공 건이 0건**인 채로 남아 있었다.

승인과 취소가 실제로 도는지만 최소 금액으로 확인할 경로를 둔다.

## 무엇

- `/payment-test` — 100원 / 1,000원 중 선택해 결제 → 관리자 화면에서 전액 환불
- `training_products.slug = 'payment-test'` + 플랜 2개 (DB 반영 완료)
- `ALLOWED_PRODUCT_SLUGS` 에 슬러그 추가

기존 결제 흐름(checkout → confirm → refund)을 그대로 타므로,
여기서 승인·취소가 되면 실제 상품에서도 같은 경로가 검증된다.

## 안전장치

- `robots: noindex, nofollow`
- 어디에서도 링크하지 않고 `sitemap.ts` 에도 넣지 않음
- 판매 페이지가 아님을 화면 문구로 명시 (결제 시 실제 청구 / 상품·서비스 제공 없음)
- **즉시 차단**: `update training_products set is_active = false where slug = 'payment-test';`
  → 페이지·checkout API 가 함께 막힌다 (코드 배포 불필요)

## 참고

- PayPal 은 KRW 미지원이라 `foreignQuote` 로 환산되며 절상 때문에 100원도 **$1** 로 청구된다.
- PayPal 은 부분환불 불가 — 전액 환불만 가능하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)