### PR TITLE
feat(payments): 결제 점검 건 자가 취소 경로

### DIFF
--- a/src/app/api/admin/training-orders/refund/route.ts
+++ b/src/app/api/admin/training-orders/refund/route.ts
@@ -1,48 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { assertAdminFromRequest } from '@/lib/admin-auth'
-import { tossSecretKey } from '@/lib/toss-keys'
-import { notifyVisaCasePayment } from '@/lib/visa-payment-ref'
+import { refundPayment } from '@/lib/payment-refund'
 
-// 결제 취소·환불.
-//
-// 회차(training_order_payments) 단위로 취소한다. PG 취소가 성공한 뒤에만 DB를 바꾼다.
-// 순서를 뒤집으면 "우리 DB는 환불됨인데 실제로는 돈이 안 나간" 상태가 생긴다.
-//
-// 부분환불은 토스만 지원한다. PayPal 은 원화가 아니라 외화로 청구돼서
-// 원화 기준 부분환불 금액을 외화로 환산하면 환율 때문에 금액이 어긋난다 — 전액만 허용한다.
-
-function getServiceRole() {
-  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
-}
+// 결제 취소·환불 (관리자).
+// 실제 취소 절차는 src/lib/payment-refund.ts 에 있다 — 결제 점검 화면과 같은 코드를 쓴다.
+// 이 라우트는 관리자 인증과 입력 검증만 맡는다.
 
 type Body = {
   paymentId?: string
   reason?: string
   /** 부분환불 금액(원). 생략하면 전액. 토스만 지원. */
   amount?: number
-}
-
-const PAYPAL_API_URL =
-  process.env.NEXT_PUBLIC_PAYPAL_SANDBOX === 'true'
-    ? 'https://api-m.sandbox.paypal.com'
-    : 'https://api-m.paypal.com'
-
-async function paypalAccessToken(): Promise<string> {
-  const id = process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID
-  const secret = process.env.PAYPAL_CLIENT_SECRET
-  if (!id || !secret) throw new Error('PayPal 키가 설정되지 않았습니다.')
-  const response = await fetch(`${PAYPAL_API_URL}/v1/oauth2/token`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Basic ${Buffer.from(`${id}:${secret}`).toString('base64')}`,
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: 'grant_type=client_credentials',
-  })
-  const data = await response.json()
-  if (!response.ok) throw new Error(data?.error_description || 'PayPal 인증 실패')
-  return data.access_token as string
 }
 
 export async function POST(request: NextRequest) {
@@ -59,216 +27,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: '결제 건을 선택해 주세요.' }, { status: 400 })
     }
 
-    const svc = getServiceRole()
-    const { data: payment, error: paymentError } = await svc
-      .from('training_order_payments')
-      .select('id, order_id, sequence, amount, status, pg_provider, payment_key, raw')
-      .eq('id', paymentId)
-      .maybeSingle()
-
-    if (paymentError || !payment) {
-      return NextResponse.json({ error: '결제 건을 찾을 수 없습니다.' }, { status: 404 })
+    const result = await refundPayment({ paymentId, reason, amount: body.amount })
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status })
     }
-    if (payment.status !== 'paid') {
-      return NextResponse.json({ error: '결제 완료 상태가 아닙니다.' }, { status: 400 })
-    }
-
-    const paidAmount = payment.amount as number
-    const requested = Number.isFinite(body.amount) ? Math.floor(body.amount as number) : paidAmount
-    if (requested <= 0 || requested > paidAmount) {
-      return NextResponse.json({ error: '환불 금액을 확인해 주세요.' }, { status: 400 })
-    }
-    const isPartial = requested < paidAmount
-
-    // 같은 결제건에 환불 요청이 두 번 들어오면 PG 에 두 번 취소가 걸린다.
-    // PG 를 부르기 전에 전용 잠금 컬럼으로 선점한다. 이미 처리 중이면 여기서 멈춘다.
-    // (표시용 필드로 선점하면 부분환불 메모와 충돌해 2차 부분환불이 막힌다.)
-    const { data: claimed } = await svc
-      .from('training_order_payments')
-      .update({ refund_lock_at: new Date().toISOString() })
-      .eq('id', payment.id)
-      .eq('status', 'paid')
-      .is('refund_lock_at', null)
-      .select('id')
-      .maybeSingle()
-
-    if (!claimed) {
-      return NextResponse.json(
-        { error: '이미 환불이 진행 중이거나 처리된 건입니다. 잠시 후 목록을 새로고침해 주세요.' },
-        { status: 409 },
-      )
-    }
-
-    // PG 호출이 실패하거나 환불이 끝나면 잠금을 푼다.
-    const releaseClaim = async () => {
-      await svc.from('training_order_payments').update({ refund_lock_at: null }).eq('id', payment.id)
-    }
-    let pgResult: unknown = null
-
-    // --- PG 취소 (실패하면 여기서 끝. DB는 건드리지 않는다) ---
-    if (payment.pg_provider === 'toss') {
-      if (!payment.payment_key) {
-        await releaseClaim()
-        return NextResponse.json({ error: '토스 결제키가 없어 취소할 수 없습니다.' }, { status: 400 })
-      }
-      const response = await fetch(
-        `https://api.tosspayments.com/v1/payments/${payment.payment_key}/cancel`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Basic ${Buffer.from(`${tossSecretKey()}:`).toString('base64')}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(
-            isPartial ? { cancelReason: reason, cancelAmount: requested } : { cancelReason: reason },
-          ),
-        },
-      )
-      pgResult = await response.json()
-      if (!response.ok) {
-        const message =
-          (pgResult as { message?: string })?.message ?? '토스 결제 취소에 실패했습니다.'
-        console.error('[training/refund] toss cancel failed:', pgResult)
-        await releaseClaim()
-        return NextResponse.json({ error: message }, { status: 502 })
-      }
-    } else if (payment.pg_provider === 'paypal') {
-      if (isPartial) {
-        await releaseClaim()
-        return NextResponse.json(
-          { error: 'PayPal 은 외화 결제라 부분환불을 지원하지 않습니다. 전액 환불만 가능합니다.' },
-          { status: 400 },
-        )
-      }
-      // 승인 시 payment_key 에 캡처 ID를 저장한다. 없으면 원본 응답에서 찾는다.
-      const raw = payment.raw as
-        | { purchase_units?: { payments?: { captures?: { id?: string }[] } }[] }
-        | null
-      const captureId =
-        (payment.payment_key as string | null) ?? raw?.purchase_units?.[0]?.payments?.captures?.[0]?.id
-      if (!captureId) {
-        await releaseClaim()
-        return NextResponse.json(
-          { error: 'PayPal 캡처 ID를 찾을 수 없습니다. PayPal 콘솔에서 직접 환불해 주세요.' },
-          { status: 400 },
-        )
-      }
-      const token = await paypalAccessToken()
-      const response = await fetch(`${PAYPAL_API_URL}/v2/payments/captures/${captureId}/refund`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-          // 같은 캡처에 대한 재요청이 두 번 환불되지 않게 한다.
-          'PayPal-Request-Id': `refund-${captureId}`,
-        },
-        body: JSON.stringify({ note_to_payer: reason.slice(0, 255) }),
-      })
-      pgResult = await response.json()
-      if (!response.ok) {
-        const message =
-          (pgResult as { message?: string })?.message ?? 'PayPal 환불에 실패했습니다.'
-        console.error('[training/refund] paypal refund failed:', pgResult)
-        await releaseClaim()
-        return NextResponse.json({ error: message }, { status: 502 })
-      }
-    } else {
-      await releaseClaim()
-      return NextResponse.json(
-        { error: `자동 환불을 지원하지 않는 결제수단입니다: ${payment.pg_provider ?? '미상'}` },
-        { status: 400 },
-      )
-    }
-
-    // --- 여기부터는 실제로 돈이 나간 상태. ---
-    const refundedAt = new Date().toISOString()
-    const remaining = paidAmount - requested
-
-    // 전액 환불이면 amount 를 건드리지 않는다.
-    // training_order_payments 에 CHECK (amount > 0) 이 있어서 0 으로 내리면 갱신이 통째로 실패하고,
-    // 그러면 "돈은 나갔는데 DB 는 결제완료" 상태가 되어 운영자가 PG 에서 한 번 더 환불하게 된다.
-    // 얼마가 환불됐는지는 status='refunded' 와 raw.refund 로 알 수 있다.
-    const paymentPatch = isPartial
-      ? {
-          status: 'paid',
-          amount: remaining,
-          failure_reason: `부분환불 ${requested.toLocaleString('ko-KR')}원: ${reason}`,
-        }
-      : { status: 'refunded', failure_reason: reason }
-
-    const { error: paymentUpdateError } = await svc
-      .from('training_order_payments')
-      .update({
-        ...paymentPatch,
-        // 승인 원본을 덮어쓰지 않는다 — PayPal 캡처 ID 등 근거가 사라진다.
-        raw: { ...(payment.raw as Record<string, unknown> | null), refund: pgResult },
-        updated_at: refundedAt,
-      })
-      .eq('id', payment.id)
-
-    if (paymentUpdateError) {
-      // 환불은 이미 성공했다. 운영자가 다시 누르지 않도록 그 사실을 분명히 알린다.
-      console.error('[training/refund] payment row update failed AFTER pg refund:', paymentUpdateError)
-      await releaseClaim()
-      return NextResponse.json(
-        {
-          error:
-            `PG 환불은 완료되었으나 기록 갱신에 실패했습니다. 다시 환불하지 마세요. ` +
-            `결제건 ${payment.id} / 환불 ${requested.toLocaleString('ko-KR')}원 — 개발자에게 알려주세요.`,
-        },
-        { status: 500 },
-      )
-    }
-
-    const { data: order } = await svc
-      .from('training_orders')
-      .select('id, order_no, total_amount, visa_application_id, discount_code')
-      .eq('id', payment.order_id)
-      .maybeSingle()
-
-    const { data: paidRows } = await svc
-      .from('training_order_payments')
-      .select('amount')
-      .eq('order_id', payment.order_id)
-      .eq('status', 'paid')
-
-    const newPaidAmount = (paidRows ?? []).reduce((sum, row) => sum + (row.amount as number), 0)
-
-    await svc
-      .from('training_orders')
-      .update({
-        paid_amount: newPaidAmount,
-        status: newPaidAmount <= 0 ? 'refunded' : newPaidAmount >= (order?.total_amount ?? 0) ? 'completed' : 'active',
-        updated_at: refundedAt,
-      })
-      .eq('id', payment.order_id)
-
-    // 전액 환불이면 할인 슬롯을 돌려준다. 안 그러면 1회용 코드가 환불 후에도 소진된 채 남는다.
-    if (order?.discount_code && newPaidAmount <= 0) {
-      await svc.from('training_discount_redemptions').delete().eq('order_id', order.id)
-    }
-
-    // 전액 환불로 주문에 남은 결제가 없어졌을 때만 케이스에 알린다.
-    // 부분환불은 여전히 "결제된 상태"라 케이스를 환불로 뒤집으면 오히려 틀린다.
-    if (order?.visa_application_id && order.order_no && newPaidAmount <= 0) {
-      await notifyVisaCasePayment({
-        applicationId: order.visa_application_id as string,
-        event: 'refunded',
-        orderNo: order.order_no,
-        provider: payment.pg_provider as 'toss' | 'paypal',
-        amountKrw: requested,
-        occurredAt: refundedAt,
-        meta: { reason, sequence: payment.sequence },
-      })
-    }
-
-    await releaseClaim()
 
     return NextResponse.json({
       success: true,
-      refundedAmount: requested,
-      remainingPaidAmount: newPaidAmount,
-      partial: isPartial,
+      refundedAmount: result.refundedAmount,
+      remainingPaidAmount: result.remainingPaidAmount,
+      partial: result.partial,
     })
   } catch (error) {
     console.error('[training/refund] unexpected error:', error)

--- a/src/app/api/payment-test/refund/route.ts
+++ b/src/app/api/payment-test/refund/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { refundPayment } from '@/lib/payment-refund'
+import { PAYMENT_TEST_MAX_AMOUNT, PAYMENT_TEST_PRODUCT_SLUG } from '@/lib/training-package'
+
+// 결제 점검 건 전용 조회·취소.
+//
+// 왜 관리자 인증이 없는가:
+//   점검을 맡는 사람(외부 자문·회계 담당)이 이 사이트의 관리자 계정을 갖고 있지 않다.
+//   관리자 권한을 새로 내주면 전체 주문·고객정보까지 함께 열리므로 과하다.
+//
+// 대신 아래 세 겹으로 범위를 못 박는다. 하나라도 어긋나면 거부한다.
+//   1) 상품이 payment-test 인 주문만
+//   2) 결제 금액이 PAYMENT_TEST_MAX_AMOUNT(1,000원) 이하인 건만
+//   3) 전액 취소만 (부분취소 없음)
+// 따라서 최악의 경우도 "우리가 만든 1,000원짜리 점검 결제가 결제자에게 되돌아간다"에 그친다.
+// 실제 판매 주문(400만원·140만원)은 1)에서 걸려 이 경로로는 손댈 수 없다.
+//
+// 결제 자체를 닫으면 이 경로도 함께 의미가 없어진다:
+//   update training_products set is_active = false where slug = 'payment-test';
+
+export const dynamic = 'force-dynamic'
+
+function getServiceRole() {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+}
+
+type PaymentRow = {
+  id: string
+  sequence: number
+  amount: number
+  status: string
+  pg_provider: string | null
+  paid_at: string | null
+  receipt_url: string | null
+}
+
+// 주문번호로 점검 주문을 찾는다. 점검 상품이 아니면 찾지 못한 것으로 처리한다
+// (실제 판매 주문의 존재 여부조차 이 경로로 알 수 없게 한다).
+async function findTestOrder(orderNo: string) {
+  const svc = getServiceRole()
+
+  const { data: product } = await svc
+    .from('training_products')
+    .select('id')
+    .eq('slug', PAYMENT_TEST_PRODUCT_SLUG)
+    .maybeSingle()
+
+  if (!product) return null
+
+  const { data: order } = await svc
+    .from('training_orders')
+    .select('id, order_no, product_id, status, total_amount, paid_amount, created_at')
+    .eq('order_no', orderNo)
+    .eq('product_id', product.id)
+    .maybeSingle()
+
+  if (!order) return null
+
+  const { data: payments } = await svc
+    .from('training_order_payments')
+    .select('id, sequence, amount, status, pg_provider, paid_at, receipt_url')
+    .eq('order_id', order.id)
+    .order('sequence', { ascending: true })
+
+  return { order, payments: (payments ?? []) as PaymentRow[] }
+}
+
+function normalizeOrderNo(value: unknown): string {
+  return String(value ?? '')
+    .trim()
+    .toUpperCase()
+}
+
+// 조회: /api/payment-test/refund?orderNo=GRT-...
+export async function GET(request: NextRequest) {
+  const orderNo = normalizeOrderNo(request.nextUrl.searchParams.get('orderNo'))
+  if (!orderNo) {
+    return NextResponse.json({ error: '주문번호를 입력해 주세요.' }, { status: 400 })
+  }
+
+  const found = await findTestOrder(orderNo)
+  if (!found) {
+    return NextResponse.json(
+      { error: '점검 결제 주문을 찾을 수 없습니다. 주문번호를 다시 확인해 주세요.' },
+      { status: 404 },
+    )
+  }
+
+  return NextResponse.json({
+    orderNo: found.order.order_no,
+    status: found.order.status,
+    totalAmount: found.order.total_amount,
+    paidAmount: found.order.paid_amount,
+    createdAt: found.order.created_at,
+    payments: found.payments,
+  })
+}
+
+// 취소: { orderNo }
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as { orderNo?: string }
+    const orderNo = normalizeOrderNo(body.orderNo)
+    if (!orderNo) {
+      return NextResponse.json({ error: '주문번호를 입력해 주세요.' }, { status: 400 })
+    }
+
+    const found = await findTestOrder(orderNo)
+    if (!found) {
+      return NextResponse.json(
+        { error: '점검 결제 주문을 찾을 수 없습니다. 주문번호를 다시 확인해 주세요.' },
+        { status: 404 },
+      )
+    }
+
+    const target = found.payments.find((row) => row.status === 'paid')
+    if (!target) {
+      const refunded = found.payments.some((row) => row.status === 'refunded')
+      return NextResponse.json(
+        {
+          error: refunded
+            ? '이미 취소된 결제입니다.'
+            : '아직 결제가 완료되지 않은 주문이라 취소할 것이 없습니다.',
+        },
+        { status: 400 },
+      )
+    }
+
+    // 금액 상한. 점검용 금액을 넘는 건은 이 경로로 취소하지 않는다.
+    if (target.amount > PAYMENT_TEST_MAX_AMOUNT) {
+      console.error('[payment-test/refund] amount over cap:', { orderNo, amount: target.amount })
+      return NextResponse.json(
+        { error: '이 경로에서는 점검용 소액 결제만 취소할 수 있습니다. 관리자에게 문의해 주세요.' },
+        { status: 400 },
+      )
+    }
+
+    const result = await refundPayment({
+      paymentId: target.id,
+      reason: '결제 점검 후 자동 취소',
+    })
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status })
+    }
+
+    return NextResponse.json({
+      success: true,
+      orderNo: found.order.order_no,
+      refundedAmount: result.refundedAmount,
+      provider: target.pg_provider,
+    })
+  } catch (error) {
+    console.error('[payment-test/refund] unexpected error:', error)
+    const message = error instanceof Error ? error.message : '취소 처리 중 오류가 발생했습니다.'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/src/app/payment-test/refund/RefundClient.tsx
+++ b/src/app/payment-test/refund/RefundClient.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { useState } from 'react'
+import { Header } from '@/components/layout/Header'
+import { Footer } from '@/components/layout/Footer'
+import { Button } from '@/components/ui/button'
+
+// 결제 점검 건 취소 화면.
+// 관리자 계정 없이도 점검 담당자가 자기가 낸 결제를 바로 되돌릴 수 있게 한다.
+// 범위 제한(점검 상품·1,000원 이하·전액만)은 서버(/api/payment-test/refund)에서 강제한다.
+
+type Payment = {
+  id: string
+  sequence: number
+  amount: number
+  status: string
+  pg_provider: string | null
+  paid_at: string | null
+  receipt_url: string | null
+}
+
+type Lookup = {
+  orderNo: string
+  status: string
+  totalAmount: number
+  paidAmount: number
+  createdAt: string
+  payments: Payment[]
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  pending: '결제 대기',
+  active: '결제 진행',
+  completed: '결제 완료',
+  refunded: '취소됨',
+  paid: '결제 완료',
+  failed: '결제 실패',
+}
+
+const PROVIDER_LABEL: Record<string, string> = { toss: '토스페이먼츠', paypal: 'PayPal' }
+
+function krw(value: number): string {
+  return `${value.toLocaleString('ko-KR')}원`
+}
+
+function formatKst(value: string | null): string {
+  if (!value) return '-'
+  try {
+    return new Intl.DateTimeFormat('ko-KR', {
+      timeZone: 'Asia/Seoul',
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(new Date(value))
+  } catch {
+    return value
+  }
+}
+
+export function RefundClient() {
+  const [orderNo, setOrderNo] = useState('')
+  const [lookup, setLookup] = useState<Lookup | null>(null)
+  const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [refunding, setRefunding] = useState(false)
+
+  const search = async () => {
+    const no = orderNo.trim().toUpperCase()
+    if (!no) {
+      setError('주문번호를 입력해 주세요.')
+      return
+    }
+    setLoading(true)
+    setError('')
+    setNotice('')
+    setLookup(null)
+    try {
+      const res = await fetch(`/api/payment-test/refund?orderNo=${encodeURIComponent(no)}`, {
+        cache: 'no-store',
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || '조회에 실패했습니다.')
+      setLookup(json as Lookup)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '조회에 실패했습니다.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const refund = async () => {
+    if (!lookup) return
+    const paid = lookup.payments.find((row) => row.status === 'paid')
+    if (!paid) return
+    if (!window.confirm(`${lookup.orderNo} 건을 ${krw(paid.amount)} 전액 취소합니다. 진행할까요?`)) {
+      return
+    }
+    setRefunding(true)
+    setError('')
+    setNotice('')
+    try {
+      const res = await fetch('/api/payment-test/refund', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orderNo: lookup.orderNo }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || '취소에 실패했습니다.')
+      setNotice(
+        `취소 완료 — ${json.orderNo} / ${krw(json.refundedAmount)}. ` +
+          '카드사 반영에는 영업일 기준 며칠이 걸릴 수 있습니다.',
+      )
+      await search()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '취소에 실패했습니다.')
+    } finally {
+      setRefunding(false)
+    }
+  }
+
+  const paidPayment = lookup?.payments.find((row) => row.status === 'paid')
+
+  return (
+    <>
+      <Header />
+      <main className="min-h-screen bg-white pt-16">
+        <div className="mx-auto max-w-2xl px-4 py-16 sm:px-6 lg:px-8">
+          <p className="text-xs font-semibold uppercase tracking-widest text-zinc-500">
+            내부 점검용
+          </p>
+          <h1 className="mt-2 text-2xl font-bold text-zinc-950">결제 점검 건 취소</h1>
+          <p className="mt-3 text-sm leading-relaxed text-zinc-600">
+            결제 점검(/payment-test)으로 결제하신 건을 전액 취소합니다.
+            <br />
+            결제 후 화면에 나온 주문번호를 입력해 주세요.
+          </p>
+
+          <div className="mt-6 rounded-lg border border-zinc-200 bg-zinc-50 p-4 text-sm leading-relaxed text-zinc-700">
+            이 화면에서는 점검용 소액 결제만 취소할 수 있습니다.
+            <br />
+            실제 판매 주문은 조회되지 않으며, 관리자 화면에서만 취소할 수 있습니다.
+          </div>
+
+          <div className="mt-8 flex flex-col gap-2 sm:flex-row">
+            <input
+              value={orderNo}
+              onChange={(event) => setOrderNo(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') search()
+              }}
+              placeholder="GRT-260823-A1B2C3"
+              className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm text-zinc-900 outline-none focus:border-zinc-900"
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <Button onClick={search} disabled={loading} className="shrink-0">
+              {loading ? '조회 중…' : '조회'}
+            </Button>
+          </div>
+
+          {error ? (
+            <p className="mt-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700">{error}</p>
+          ) : null}
+          {notice ? (
+            <p className="mt-4 rounded-md bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+              {notice}
+            </p>
+          ) : null}
+
+          {lookup ? (
+            <div className="mt-8 rounded-lg border border-zinc-200">
+              <div className="border-b border-zinc-200 px-5 py-4">
+                <p className="font-mono text-sm font-semibold text-zinc-950">{lookup.orderNo}</p>
+                <p className="mt-1 text-xs text-zinc-500">
+                  {formatKst(lookup.createdAt)} · {STATUS_LABEL[lookup.status] ?? lookup.status}
+                </p>
+              </div>
+
+              <div className="divide-y divide-zinc-100">
+                {lookup.payments.map((payment) => (
+                  <div
+                    key={payment.id}
+                    className="flex flex-wrap items-center justify-between gap-3 px-5 py-4"
+                  >
+                    <div className="text-sm text-zinc-700">
+                      <span className="font-semibold text-zinc-950">{krw(payment.amount)}</span>
+                      <span className="ml-2 text-zinc-500">
+                        {payment.pg_provider
+                          ? (PROVIDER_LABEL[payment.pg_provider] ?? payment.pg_provider)
+                          : '결제수단 미정'}
+                      </span>
+                      <span className="ml-2 text-zinc-500">
+                        {STATUS_LABEL[payment.status] ?? payment.status}
+                      </span>
+                      {payment.paid_at ? (
+                        <span className="ml-2 text-zinc-400">{formatKst(payment.paid_at)}</span>
+                      ) : null}
+                    </div>
+                    {payment.receipt_url ? (
+                      <a
+                        href={payment.receipt_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-xs text-zinc-500 underline"
+                      >
+                        영수증
+                      </a>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+
+              <div className="border-t border-zinc-200 px-5 py-4">
+                {paidPayment ? (
+                  <Button
+                    onClick={refund}
+                    disabled={refunding}
+                    variant="destructive"
+                    className="w-full sm:w-auto"
+                  >
+                    {refunding ? '취소 중…' : `${krw(paidPayment.amount)} 전액 취소`}
+                  </Button>
+                ) : (
+                  <p className="text-sm text-zinc-500">취소할 결제 완료 건이 없습니다.</p>
+                )}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/app/payment-test/refund/page.tsx
+++ b/src/app/payment-test/refund/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+import { RefundClient } from './RefundClient'
+
+// 결제 점검 건 취소 화면 (내부용).
+// 관리자 계정이 없는 점검 담당자도 자기가 낸 소액 결제를 바로 되돌릴 수 있게 한다.
+// 범위 제한은 서버(/api/payment-test/refund)에서 강제한다 — 점검 상품·1,000원 이하·전액만.
+export const metadata: Metadata = {
+  title: '결제 점검 건 취소 - 그리고 엔터테인먼트',
+  description: '결제 점검용 소액 결제를 전액 취소하는 내부 점검용 화면입니다.',
+  robots: { index: false, follow: false },
+}
+
+export default function PaymentTestRefundPage() {
+  return <RefundClient />
+}

--- a/src/lib/payment-refund.ts
+++ b/src/lib/payment-refund.ts
@@ -1,0 +1,272 @@
+import { createClient } from '@supabase/supabase-js'
+import { tossSecretKey } from '@/lib/toss-keys'
+import { notifyVisaCasePayment } from '@/lib/visa-payment-ref'
+
+// 결제 취소·환불 코어.
+//
+// 관리자 화면(/api/admin/training-orders/refund)과 결제 점검 화면(/api/payment-test/refund)이
+// 같은 로직을 쓴다. 취소 절차가 두 벌로 갈라지면 한쪽만 고쳐져
+// "돈은 나갔는데 DB 는 결제완료" 같은 사고가 한쪽에서만 재발한다.
+//
+// 회차(training_order_payments) 단위로 취소한다. PG 취소가 성공한 뒤에만 DB를 바꾼다.
+// 순서를 뒤집으면 "우리 DB는 환불됨인데 실제로는 돈이 안 나간" 상태가 생긴다.
+//
+// 부분환불은 토스만 지원한다. PayPal 은 원화가 아니라 외화로 청구돼서
+// 원화 기준 부분환불 금액을 외화로 환산하면 환율 때문에 금액이 어긋난다 — 전액만 허용한다.
+
+export type RefundResult =
+  | { ok: true; refundedAmount: number; remainingPaidAmount: number; partial: boolean }
+  | { ok: false; status: number; error: string }
+
+function getServiceRole() {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!)
+}
+
+const PAYPAL_API_URL =
+  process.env.NEXT_PUBLIC_PAYPAL_SANDBOX === 'true'
+    ? 'https://api-m.sandbox.paypal.com'
+    : 'https://api-m.paypal.com'
+
+async function paypalAccessToken(): Promise<string> {
+  const id = process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID
+  const secret = process.env.PAYPAL_CLIENT_SECRET
+  if (!id || !secret) throw new Error('PayPal 키가 설정되지 않았습니다.')
+  const response = await fetch(`${PAYPAL_API_URL}/v1/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${id}:${secret}`).toString('base64')}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: 'grant_type=client_credentials',
+  })
+  const data = await response.json()
+  if (!response.ok) throw new Error(data?.error_description || 'PayPal 인증 실패')
+  return data.access_token as string
+}
+
+export async function refundPayment(params: {
+  paymentId: string
+  reason: string
+  /** 부분환불 금액(원). 생략하면 전액. 토스만 지원. */
+  amount?: number
+}): Promise<RefundResult> {
+  const { paymentId, reason } = params
+  const svc = getServiceRole()
+
+  const { data: payment, error: paymentError } = await svc
+    .from('training_order_payments')
+    .select('id, order_id, sequence, amount, status, pg_provider, payment_key, raw')
+    .eq('id', paymentId)
+    .maybeSingle()
+
+  if (paymentError || !payment) {
+    return { ok: false, status: 404, error: '결제 건을 찾을 수 없습니다.' }
+  }
+  if (payment.status !== 'paid') {
+    return { ok: false, status: 400, error: '결제 완료 상태가 아닙니다.' }
+  }
+
+  const paidAmount = payment.amount as number
+  const requested = Number.isFinite(params.amount) ? Math.floor(params.amount as number) : paidAmount
+  if (requested <= 0 || requested > paidAmount) {
+    return { ok: false, status: 400, error: '환불 금액을 확인해 주세요.' }
+  }
+  const isPartial = requested < paidAmount
+
+  // 같은 결제건에 환불 요청이 두 번 들어오면 PG 에 두 번 취소가 걸린다.
+  // PG 를 부르기 전에 전용 잠금 컬럼으로 선점한다. 이미 처리 중이면 여기서 멈춘다.
+  // (표시용 필드로 선점하면 부분환불 메모와 충돌해 2차 부분환불이 막힌다.)
+  const { data: claimed } = await svc
+    .from('training_order_payments')
+    .update({ refund_lock_at: new Date().toISOString() })
+    .eq('id', payment.id)
+    .eq('status', 'paid')
+    .is('refund_lock_at', null)
+    .select('id')
+    .maybeSingle()
+
+  if (!claimed) {
+    return {
+      ok: false,
+      status: 409,
+      error: '이미 환불이 진행 중이거나 처리된 건입니다. 잠시 후 목록을 새로고침해 주세요.',
+    }
+  }
+
+  // PG 호출이 실패하거나 환불이 끝나면 잠금을 푼다.
+  const releaseClaim = async () => {
+    await svc.from('training_order_payments').update({ refund_lock_at: null }).eq('id', payment.id)
+  }
+  let pgResult: unknown = null
+
+  // --- PG 취소 (실패하면 여기서 끝. DB는 건드리지 않는다) ---
+  if (payment.pg_provider === 'toss') {
+    if (!payment.payment_key) {
+      await releaseClaim()
+      return { ok: false, status: 400, error: '토스 결제키가 없어 취소할 수 없습니다.' }
+    }
+    const response = await fetch(
+      `https://api.tosspayments.com/v1/payments/${payment.payment_key}/cancel`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${Buffer.from(`${tossSecretKey()}:`).toString('base64')}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(
+          isPartial ? { cancelReason: reason, cancelAmount: requested } : { cancelReason: reason },
+        ),
+      },
+    )
+    pgResult = await response.json()
+    if (!response.ok) {
+      const message = (pgResult as { message?: string })?.message ?? '토스 결제 취소에 실패했습니다.'
+      console.error('[payment/refund] toss cancel failed:', pgResult)
+      await releaseClaim()
+      return { ok: false, status: 502, error: message }
+    }
+  } else if (payment.pg_provider === 'paypal') {
+    if (isPartial) {
+      await releaseClaim()
+      return {
+        ok: false,
+        status: 400,
+        error: 'PayPal 은 외화 결제라 부분환불을 지원하지 않습니다. 전액 환불만 가능합니다.',
+      }
+    }
+    // 승인 시 payment_key 에 캡처 ID를 저장한다. 없으면 원본 응답에서 찾는다.
+    const raw = payment.raw as
+      | { purchase_units?: { payments?: { captures?: { id?: string }[] } }[] }
+      | null
+    const captureId =
+      (payment.payment_key as string | null) ?? raw?.purchase_units?.[0]?.payments?.captures?.[0]?.id
+    if (!captureId) {
+      await releaseClaim()
+      return {
+        ok: false,
+        status: 400,
+        error: 'PayPal 캡처 ID를 찾을 수 없습니다. PayPal 콘솔에서 직접 환불해 주세요.',
+      }
+    }
+    const token = await paypalAccessToken()
+    const response = await fetch(`${PAYPAL_API_URL}/v2/payments/captures/${captureId}/refund`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        // 같은 캡처에 대한 재요청이 두 번 환불되지 않게 한다.
+        'PayPal-Request-Id': `refund-${captureId}`,
+      },
+      body: JSON.stringify({ note_to_payer: reason.slice(0, 255) }),
+    })
+    pgResult = await response.json()
+    if (!response.ok) {
+      const message = (pgResult as { message?: string })?.message ?? 'PayPal 환불에 실패했습니다.'
+      console.error('[payment/refund] paypal refund failed:', pgResult)
+      await releaseClaim()
+      return { ok: false, status: 502, error: message }
+    }
+  } else {
+    await releaseClaim()
+    return {
+      ok: false,
+      status: 400,
+      error: `자동 환불을 지원하지 않는 결제수단입니다: ${payment.pg_provider ?? '미상'}`,
+    }
+  }
+
+  // --- 여기부터는 실제로 돈이 나간 상태. ---
+  const refundedAt = new Date().toISOString()
+  const remaining = paidAmount - requested
+
+  // 전액 환불이면 amount 를 건드리지 않는다.
+  // training_order_payments 에 CHECK (amount > 0) 이 있어서 0 으로 내리면 갱신이 통째로 실패하고,
+  // 그러면 "돈은 나갔는데 DB 는 결제완료" 상태가 되어 운영자가 PG 에서 한 번 더 환불하게 된다.
+  // 얼마가 환불됐는지는 status='refunded' 와 raw.refund 로 알 수 있다.
+  const paymentPatch = isPartial
+    ? {
+        status: 'paid',
+        amount: remaining,
+        failure_reason: `부분환불 ${requested.toLocaleString('ko-KR')}원: ${reason}`,
+      }
+    : { status: 'refunded', failure_reason: reason }
+
+  const { error: paymentUpdateError } = await svc
+    .from('training_order_payments')
+    .update({
+      ...paymentPatch,
+      // 승인 원본을 덮어쓰지 않는다 — PayPal 캡처 ID 등 근거가 사라진다.
+      raw: { ...(payment.raw as Record<string, unknown> | null), refund: pgResult },
+      updated_at: refundedAt,
+    })
+    .eq('id', payment.id)
+
+  if (paymentUpdateError) {
+    // 환불은 이미 성공했다. 운영자가 다시 누르지 않도록 그 사실을 분명히 알린다.
+    console.error('[payment/refund] payment row update failed AFTER pg refund:', paymentUpdateError)
+    await releaseClaim()
+    return {
+      ok: false,
+      status: 500,
+      error:
+        `PG 환불은 완료되었으나 기록 갱신에 실패했습니다. 다시 환불하지 마세요. ` +
+        `결제건 ${payment.id} / 환불 ${requested.toLocaleString('ko-KR')}원 — 개발자에게 알려주세요.`,
+    }
+  }
+
+  const { data: order } = await svc
+    .from('training_orders')
+    .select('id, order_no, total_amount, visa_application_id, discount_code')
+    .eq('id', payment.order_id)
+    .maybeSingle()
+
+  const { data: paidRows } = await svc
+    .from('training_order_payments')
+    .select('amount')
+    .eq('order_id', payment.order_id)
+    .eq('status', 'paid')
+
+  const newPaidAmount = (paidRows ?? []).reduce((sum, row) => sum + (row.amount as number), 0)
+
+  await svc
+    .from('training_orders')
+    .update({
+      paid_amount: newPaidAmount,
+      status:
+        newPaidAmount <= 0
+          ? 'refunded'
+          : newPaidAmount >= (order?.total_amount ?? 0)
+            ? 'completed'
+            : 'active',
+      updated_at: refundedAt,
+    })
+    .eq('id', payment.order_id)
+
+  // 전액 환불이면 할인 슬롯을 돌려준다. 안 그러면 1회용 코드가 환불 후에도 소진된 채 남는다.
+  if (order?.discount_code && newPaidAmount <= 0) {
+    await svc.from('training_discount_redemptions').delete().eq('order_id', order.id)
+  }
+
+  // 전액 환불로 주문에 남은 결제가 없어졌을 때만 케이스에 알린다.
+  // 부분환불은 여전히 "결제된 상태"라 케이스를 환불로 뒤집으면 오히려 틀린다.
+  if (order?.visa_application_id && order.order_no && newPaidAmount <= 0) {
+    await notifyVisaCasePayment({
+      applicationId: order.visa_application_id as string,
+      event: 'refunded',
+      orderNo: order.order_no,
+      provider: payment.pg_provider as 'toss' | 'paypal',
+      amountKrw: requested,
+      occurredAt: refundedAt,
+      meta: { reason, sequence: payment.sequence },
+    })
+  }
+
+  await releaseClaim()
+
+  return {
+    ok: true,
+    refundedAmount: requested,
+    remainingPaidAmount: newPaidAmount,
+    partial: isPartial,
+  }
+}

--- a/src/lib/training-package.ts
+++ b/src/lib/training-package.ts
@@ -610,6 +610,10 @@ export const MONTHLY_TRAINING_PRODUCT_SLUG = 'monthly-training'
 //   → 페이지는 "판매 중인 상품이 없습니다"로 바뀌고 checkout API 도 404 로 막힌다.
 export const PAYMENT_TEST_PRODUCT_SLUG = 'payment-test'
 
+// 점검용 취소 경로(/api/payment-test/refund)가 손댈 수 있는 금액 상한.
+// 이 위로는 관리자 화면에서만 취소할 수 있다 — 실제 판매 주문이 섞여 들어오는 것을 막는다.
+export const PAYMENT_TEST_MAX_AMOUNT = 1000
+
 export const PAYMENT_TEST_COPY: Record<
   TrainingLang,
   {
@@ -631,6 +635,7 @@ export const PAYMENT_TEST_COPY: Record<
       items: [
         '이 페이지는 판매 페이지가 아니라 결제 수단이 정상 동작하는지 확인하기 위한 내부 점검용 경로입니다.',
         '결제하시면 실제로 대금이 청구됩니다. 점검이 끝나면 바로 전액 취소합니다.',
+        '취소는 결제 후 받으시는 주문번호로 /payment-test/refund 에서 직접 하실 수 있습니다.',
         '어떤 상품이나 서비스도 제공되지 않습니다.',
         '고객님께서 이 페이지에 잘못 들어오셨다면 결제하지 마시고 창을 닫아 주세요.',
       ],
@@ -649,6 +654,7 @@ export const PAYMENT_TEST_COPY: Record<
       items: [
         'This is not a sales page. It exists only to verify that our payment methods work.',
         'A payment made here is a real charge. It is refunded in full as soon as the check is done.',
+        'You can cancel it yourself at /payment-test/refund using the order number shown after payment.',
         'No product or service is provided.',
         'If you reached this page by mistake, please close it without paying.',
       ],
@@ -667,6 +673,7 @@ export const PAYMENT_TEST_COPY: Record<
       items: [
         'こちらは販売ページではなく、決済手段が正常に動作するかを確認するための内部点検用ページです。',
         '決済すると実際に請求が発生します。点検が終わり次第、全額を取り消します。',
+        '取消は決済後に表示される注文番号を使って /payment-test/refund でご自身で行えます。',
         '商品やサービスの提供はありません。',
         '誤ってこのページに入られた場合は、決済せずに閉じてください。',
       ],


### PR DESCRIPTION
## 왜

점검을 맡는 `hs@astcompany.co.kr`·`odh@grigoent.co.kr` 는 **grigoent 계정 자체가 없다**.
(관리자는 `tommy0621@naver.com` 한 명뿐)

앞선 메일에서 "결제 후 `/admin/training-orders` 에서 전액 환불"을 안내했는데, 두 사람은 그 화면에 들어갈 수 없다.
관리자 권한을 새로 내주면 전체 주문·고객정보까지 함께 열리므로 과하다.

## 무엇

- `/payment-test/refund` — 결제 후 받은 주문번호를 넣고 전액 취소
- `/api/payment-test/refund` — GET 조회 / POST 취소

## 범위 제한 (서버에서 강제, 3중)

1. 상품이 `payment-test` 인 주문만 — 실제 판매 주문은 **조회조차 되지 않는다**
2. 결제 금액 `PAYMENT_TEST_MAX_AMOUNT`(1,000원) 이하만
3. 전액 취소만 (부분취소 없음)

최악의 경우도 "우리가 만든 1,000원짜리 점검 결제가 결제자에게 되돌아간다"에 그친다.

## 리팩터링

취소 코어를 `src/lib/payment-refund.ts` 로 추출했다.
관리자 경로와 점검 경로가 **같은 절차**를 쓴다 — 두 벌로 갈라지면 한쪽만 고쳐져 "돈은 나갔는데 DB 는 결제완료" 사고가 한쪽에서만 재발한다.

관리자 라우트는 인증·입력검증만 남기고 동작은 그대로다 (잠금 컬럼·PG 선행·부분환불 규칙 모두 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)